### PR TITLE
Add optional server variable 

### DIFF
--- a/config/websockets.php
+++ b/config/websockets.php
@@ -13,6 +13,7 @@ return [
         [
             'id' => env('PUSHER_APP_ID'),
             'name' => env('APP_NAME'),
+            'server' => null,
             'key' => env('PUSHER_APP_KEY'),
             'secret' => env('PUSHER_APP_SECRET'),
             'enable_client_messages' => false,

--- a/config/websockets.php
+++ b/config/websockets.php
@@ -13,7 +13,6 @@ return [
         [
             'id' => env('PUSHER_APP_ID'),
             'name' => env('APP_NAME'),
-            'server' => null,
             'key' => env('PUSHER_APP_KEY'),
             'secret' => env('PUSHER_APP_SECRET'),
             'enable_client_messages' => false,

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -109,7 +109,7 @@
         methods: {
             connect() {
                 this.pusher = new Pusher(this.app.key, {
-                    wsHost: window.location.hostname,
+                    wsHost: this.app.server.length === 0 ? window.location.hostname : this.app.server,
                     wsPort: this.port,
                     disableStats: true,
                     authEndpoint: '/{{ request()->path() }}/auth',

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -109,7 +109,7 @@
         methods: {
             connect() {
                 this.pusher = new Pusher(this.app.key, {
-                    wsHost: this.app.server.length === 0 ? window.location.hostname : this.app.server,
+                    wsHost: this.app.host.length === 0 ? window.location.hostname : this.app.host,
                     wsPort: this.port,
                     disableStats: true,
                     authEndpoint: '/{{ request()->path() }}/auth',

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -109,7 +109,7 @@
         methods: {
             connect() {
                 this.pusher = new Pusher(this.app.key, {
-                    wsHost: this.app.host.length === 0 ? window.location.hostname : this.app.host,
+                    wsHost: this.app.host === null ? window.location.hostname : this.app.host,
                     wsPort: this.port,
                     disableStats: true,
                     authEndpoint: '/{{ request()->path() }}/auth',

--- a/src/Apps/App.php
+++ b/src/Apps/App.php
@@ -19,7 +19,7 @@ class App
     public $name;
 
     /** @var string|null */
-    public $server;
+    public $host;
 
     /** @var bool */
     public $clientMessagesEnabled = false;
@@ -66,9 +66,9 @@ class App
         return $this;
     }
 
-    public function setServer(string $server)
+    public function setHost(string $host)
     {
-        $this->server = $server;
+        $this->host = $host;
 
         return $this;
     }

--- a/src/Apps/App.php
+++ b/src/Apps/App.php
@@ -18,6 +18,9 @@ class App
     /** @var string|null */
     public $name;
 
+    /** @var string|null */
+    public $server;
+
     /** @var bool */
     public $clientMessagesEnabled = false;
 
@@ -59,6 +62,13 @@ class App
     public function setName(string $appName)
     {
         $this->name = $appName;
+
+        return $this;
+    }
+
+    public function setServer(string $server)
+    {
+        $this->server = $server;
 
         return $this;
     }

--- a/src/Apps/ConfigAppProvider.php
+++ b/src/Apps/ConfigAppProvider.php
@@ -67,6 +67,10 @@ class ConfigAppProvider implements AppProvider
             $app->setName($appAttributes['name']);
         }
 
+        if (isset($appAttributes['server'])) {
+            $app->setServer($appAttributes['server']);
+        }
+
         $app
             ->enableClientMessages($appAttributes['enable_client_messages'])
             ->enableStatistics($appAttributes['enable_statistics']);

--- a/src/Apps/ConfigAppProvider.php
+++ b/src/Apps/ConfigAppProvider.php
@@ -67,8 +67,8 @@ class ConfigAppProvider implements AppProvider
             $app->setName($appAttributes['name']);
         }
 
-        if (isset($appAttributes['server'])) {
-            $app->setServer($appAttributes['server']);
+        if (isset($appAttributes['host'])) {
+            $app->setHost($appAttributes['host']);
         }
 
         $app


### PR DESCRIPTION
This PR fixes https://github.com/beyondcode/laravel-websockets/issues/12

It is now possible to easily configure the server, which the dashboard connects to.

My setup is the following:
I have one server (the webserver) which is hosting the dashboard: dev.my.app
The socket server is running under ws-dev.my.app 

Without this PR, the dashboard tries to conntect to dev.my.app because, in the connect section `window.location.hostname` is used. This behavior is after this pr still the same, except someone fills the new 'server' configuration variable. Then this value will be used.  