### PR TITLE
[WIP] Allow disabling the dashboard routes

### DIFF
--- a/src/WebSocketsServiceProvider.php
+++ b/src/WebSocketsServiceProvider.php
@@ -30,11 +30,13 @@ class WebSocketsServiceProvider extends ServiceProvider
             ], 'migrations');
         }
 
-        $this
-            ->registerRoutes()
-            ->registerDashboardGate();
+        if (config('websockets.path') !== null) {
+            $this
+                ->registerRoutes()
+                ->registerDashboardGate();
 
-        $this->loadViewsFrom(__DIR__.'/../resources/views/', 'websockets');
+            $this->loadViewsFrom(__DIR__.'/../resources/views/', 'websockets');
+        }
 
         $this->commands([
             Console\StartWebSocketServer::class,


### PR DESCRIPTION
These routes don't work in my app without the correct middleware group applied and I don't want that route in production on every domain so I would like to be able to disable the dashboard all together if there is no path defined so it can be disabled and/or replaced by our own.