### PR TITLE
Use an actual DNS resolver

### DIFF
--- a/config/websockets.php
+++ b/config/websockets.php
@@ -65,6 +65,12 @@ return [
          * the number of days specified here will be deleted.
          */
         'delete_statistics_older_than_days' => 60,
+
+        /*
+         * Use an DNS resolver to make the requests to the statistics logger
+         * default is to resolve everything to 127.0.0.1.
+         */
+        'perform_dns_lookup' => false,
     ],
 
     /*


### PR DESCRIPTION
Without this the statistics requests will never reach the server if it's not available on 127.0.0.1 directly (think load balanced or distributed services). 

Let the system supply a DNS resolver or use Cloudflare's 1.1.1.1 as an default.