### PR TITLE
Fix namespace in StatisticsUpdated.php

### DIFF
--- a/src/Statistics/Events/StatisticsUpdated.php
+++ b/src/Statistics/Events/StatisticsUpdated.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace BeyondCode\LaravelWebsockets\Statistics\Events;
+namespace BeyondCode\LaravelWebSockets\Statistics\Events;
 
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Broadcasting\PrivateChannel;


### PR DESCRIPTION
The spelling mistake will cause the following error when the queue worker tries to unserialize the event class:
>method_exists(): The script tried to execute a method or access a property of an incomplete object. Please ensure that the class definition "BeyondCode\LaravelWebsockets\Statistics\Events\StatisticsUpdated" of the object you are trying to operate on was loaded _before_ unserialize() gets called or provide an autoloader to load the class definition

This may be a Windows specific bug, otherwise there would have been more reports I guess.

Btw. I also searched the other files for spelling mistakes in the namespaces, but everything looks fine.