### PR TITLE
Fix Namespace

### DIFF
--- a/src/Server/HttpServer.php
+++ b/src/Server/HttpServer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace BeyondCode\LaravelWebsockets\Server;
+namespace BeyondCode\LaravelWebSockets\Server;
 
 use Ratchet\Http\HttpServerInterface;
 

--- a/src/Statistics/Events/StatisticsUpdated.php
+++ b/src/Statistics/Events/StatisticsUpdated.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace BeyondCode\LaravelWebsockets\Statistics\Events;
+namespace BeyondCode\LaravelWebSockets\Statistics\Events;
 
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Broadcasting\PrivateChannel;

--- a/tests/Channels/ChannelTest.php
+++ b/tests/Channels/ChannelTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace BeyondCode\LaravelWebsockets\Tests\Channels;
+namespace BeyondCode\LaravelWebSockets\Tests\Channels;
 
 use BeyondCode\LaravelWebSockets\Tests\TestCase;
 use BeyondCode\LaravelWebSockets\Tests\Mocks\Message;

--- a/tests/Channels/PresenceChannelTest.php
+++ b/tests/Channels/PresenceChannelTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace BeyondCode\LaravelWebsockets\Tests\Channels;
+namespace BeyondCode\LaravelWebSockets\Tests\Channels;
 
 use BeyondCode\LaravelWebSockets\Tests\TestCase;
 use BeyondCode\LaravelWebSockets\Tests\Mocks\Message;

--- a/tests/Channels/PrivateChannelTest.php
+++ b/tests/Channels/PrivateChannelTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace BeyondCode\LaravelWebsockets\Tests\Channels;
+namespace BeyondCode\LaravelWebSockets\Tests\Channels;
 
 use BeyondCode\LaravelWebSockets\Tests\TestCase;
 use BeyondCode\LaravelWebSockets\Tests\Mocks\Message;

--- a/tests/Messages/PusherClientMessageTest.php
+++ b/tests/Messages/PusherClientMessageTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace BeyondCode\LaravelWebsockets\Tests\Messages;
+namespace BeyondCode\LaravelWebSockets\Tests\Messages;
 
 use BeyondCode\LaravelWebSockets\Tests\TestCase;
 use BeyondCode\LaravelWebSockets\Tests\Mocks\Message;


### PR DESCRIPTION
Some classes had namespace issues and it looks like the reason we're seeing the error referred in #10 is due to the namespace being wrong here and when it tries to call, it breaks.

I ran a few tests and the `StatisticsUpdated` job is running fine now (Been testing for the last few hours now, no issues).

