### PR TITLE
Fix signature validation

### DIFF
--- a/src/HttpApi/Controllers/Controller.php
+++ b/src/HttpApi/Controllers/Controller.php
@@ -3,6 +3,7 @@
 namespace BeyondCode\LaravelWebSockets\HttpApi\Controllers;
 
 use Exception;
+use Pusher\Pusher;
 use Illuminate\Http\Request;
 use GuzzleHttp\Psr7\Response;
 use Ratchet\ConnectionInterface;
@@ -84,17 +85,15 @@ abstract class Controller implements HttpServerInterface
 
     protected function ensureValidSignature(Request $request)
     {
-        $signature =
-            "{$request->getMethod()}\n/{$request->path()}\n".
-            "auth_key={$request->get('auth_key')}".
-            "&auth_timestamp={$request->get('auth_timestamp')}".
-            "&auth_version={$request->get('auth_version')}";
+        $params = array_except($request->query(), ['auth_signature', 'body_md5']);
 
         if ($request->getContent() !== '') {
-            $bodyMd5 = md5($request->getContent());
-
-            $signature .= "&body_md5={$bodyMd5}";
+            $params['body_md5'] = md5($request->getContent());
         }
+
+        ksort($params);
+
+        $signature = "{$request->getMethod()}\n/{$request->path()}\n" . Pusher::array_implode('=', '&', $params);
 
         $authSignature = hash_hmac('sha256', $signature, App::findById($request->get('appId'))->secret);
 

--- a/src/HttpApi/Controllers/Controller.php
+++ b/src/HttpApi/Controllers/Controller.php
@@ -85,7 +85,12 @@ abstract class Controller implements HttpServerInterface
 
     protected function ensureValidSignature(Request $request)
     {
-        $params = array_except($request->query(), ['auth_signature', 'body_md5']);
+        /*
+         * The `auth_signature` & `body_md5` parameters are not included when calculating the `auth_signature` value.
+         *
+         * The `appId`, `appKey` & `channelName` parameters are actually route paramaters and are never supplied by the client.
+         */
+        $params = array_except($request->query(), ['auth_signature', 'body_md5', 'appId', 'appKey', 'channelName']);
 
         if ($request->getContent() !== '') {
             $params['body_md5'] = md5($request->getContent());

--- a/src/HttpApi/Controllers/Controller.php
+++ b/src/HttpApi/Controllers/Controller.php
@@ -93,7 +93,7 @@ abstract class Controller implements HttpServerInterface
 
         ksort($params);
 
-        $signature = "{$request->getMethod()}\n/{$request->path()}\n" . Pusher::array_implode('=', '&', $params);
+        $signature = "{$request->getMethod()}\n/{$request->path()}\n".Pusher::array_implode('=', '&', $params);
 
         $authSignature = hash_hmac('sha256', $signature, App::findById($request->get('appId'))->secret);
 

--- a/tests/HttpApi/FetchChannelTest.php
+++ b/tests/HttpApi/FetchChannelTest.php
@@ -2,6 +2,7 @@
 
 namespace BeyondCode\LaravelWebSockets\Tests\HttpApi;
 
+use Pusher\Pusher;
 use GuzzleHttp\Psr7\Request;
 use Illuminate\Http\JsonResponse;
 use BeyondCode\LaravelWebSockets\Tests\TestCase;
@@ -19,21 +20,14 @@ class FetchChannelTest extends TestCase
 
         $connection = new Connection();
 
-        $auth_key = 'TestKey';
-        $auth_timestamp = time();
-        $auth_version = '1.0';
+        $requestPath = '/apps/1234/channel/my-channel';
 
-        $queryParameters = http_build_query(compact('auth_key', 'auth_timestamp', 'auth_version'));
+        $queryString = Pusher::build_auth_query_string('TestKey', 'InvalidSecret', 'GET', $requestPath, [
+            'appId' => '1234',
+            'channelName' => 'my-channel',
+        ]);
 
-        $signature =
-            "GET\n/apps/1234/channels\n".
-            "auth_key={$auth_key}".
-            "&auth_timestamp={$auth_timestamp}".
-            "&auth_version={$auth_version}";
-
-        $auth_signature = hash_hmac('sha256', $signature, 'InvalidSecret');
-
-        $request = new Request('GET', "/apps/1234/channel/my-channel?appId=1234&channelName=my-channel&auth_signature={$auth_signature}&{$queryParameters}");
+        $request = new Request('GET', "{$requestPath}?{$queryString}");
 
         $controller = app(FetchChannelController::class);
 
@@ -48,21 +42,14 @@ class FetchChannelTest extends TestCase
 
         $connection = new Connection();
 
-        $auth_key = 'TestKey';
-        $auth_timestamp = time();
-        $auth_version = '1.0';
+        $requestPath = '/apps/1234/channel/my-channel';
 
-        $queryParameters = http_build_query(compact('auth_key', 'auth_timestamp', 'auth_version'));
+        $queryString = Pusher::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath, [
+            'appId' => '1234',
+            'channelName' => 'my-channel',
+        ]);
 
-        $signature =
-            "GET\n/apps/1234/channel/my-channel\n".
-            "auth_key={$auth_key}".
-            "&auth_timestamp={$auth_timestamp}".
-            "&auth_version={$auth_version}";
-
-        $auth_signature = hash_hmac('sha256', $signature, 'TestSecret');
-
-        $request = new Request('GET', "/apps/1234/channel/my-channel?appId=1234&channelName=my-channel&auth_signature={$auth_signature}&{$queryParameters}");
+        $request = new Request('GET', "{$requestPath}?{$queryString}");
 
         $controller = app(FetchChannelController::class);
 
@@ -87,21 +74,14 @@ class FetchChannelTest extends TestCase
 
         $connection = new Connection();
 
-        $auth_key = 'TestKey';
-        $auth_timestamp = time();
-        $auth_version = '1.0';
+        $requestPath = '/apps/1234/channel/invalid-channel';
 
-        $queryParameters = http_build_query(compact('auth_key', 'auth_timestamp', 'auth_version'));
+        $queryString = Pusher::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath, [
+            'appId' => '1234',
+            'channelName' => 'invalid-channel',
+        ]);
 
-        $signature =
-            "GET\n/apps/1234/channel/my-channel\n".
-            "auth_key={$auth_key}".
-            "&auth_timestamp={$auth_timestamp}".
-            "&auth_version={$auth_version}";
-
-        $auth_signature = hash_hmac('sha256', $signature, 'TestSecret');
-
-        $request = new Request('GET', "/apps/1234/channel/my-channel?appId=1234&channelName=invalid-channel&auth_signature={$auth_signature}&{$queryParameters}");
+        $request = new Request('GET', "{$requestPath}?{$queryString}");
 
         $controller = app(FetchChannelController::class);
 

--- a/tests/HttpApi/FetchChannelTest.php
+++ b/tests/HttpApi/FetchChannelTest.php
@@ -21,13 +21,14 @@ class FetchChannelTest extends TestCase
         $connection = new Connection();
 
         $requestPath = '/apps/1234/channel/my-channel';
-
-        $queryString = Pusher::build_auth_query_string('TestKey', 'InvalidSecret', 'GET', $requestPath, [
+        $routeParams = [
             'appId' => '1234',
             'channelName' => 'my-channel',
-        ]);
+        ];
 
-        $request = new Request('GET', "{$requestPath}?{$queryString}");
+        $queryString = Pusher::build_auth_query_string('TestKey', 'InvalidSecret', 'GET', $requestPath);
+
+        $request = new Request('GET', "{$requestPath}?{$queryString}&".http_build_query($routeParams));
 
         $controller = app(FetchChannelController::class);
 
@@ -43,13 +44,14 @@ class FetchChannelTest extends TestCase
         $connection = new Connection();
 
         $requestPath = '/apps/1234/channel/my-channel';
-
-        $queryString = Pusher::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath, [
+        $routeParams = [
             'appId' => '1234',
             'channelName' => 'my-channel',
-        ]);
+        ];
 
-        $request = new Request('GET', "{$requestPath}?{$queryString}");
+        $queryString = Pusher::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath);
+
+        $request = new Request('GET', "{$requestPath}?{$queryString}&".http_build_query($routeParams));
 
         $controller = app(FetchChannelController::class);
 
@@ -75,13 +77,14 @@ class FetchChannelTest extends TestCase
         $connection = new Connection();
 
         $requestPath = '/apps/1234/channel/invalid-channel';
-
-        $queryString = Pusher::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath, [
+        $routeParams = [
             'appId' => '1234',
             'channelName' => 'invalid-channel',
-        ]);
+        ];
 
-        $request = new Request('GET', "{$requestPath}?{$queryString}");
+        $queryString = Pusher::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath);
+
+        $request = new Request('GET', "{$requestPath}?{$queryString}&".http_build_query($routeParams));
 
         $controller = app(FetchChannelController::class);
 

--- a/tests/HttpApi/FetchChannelsTest.php
+++ b/tests/HttpApi/FetchChannelsTest.php
@@ -2,6 +2,7 @@
 
 namespace BeyondCode\LaravelWebSockets\Tests\HttpApi;
 
+use Pusher\Pusher;
 use GuzzleHttp\Psr7\Request;
 use Illuminate\Http\JsonResponse;
 use BeyondCode\LaravelWebSockets\Tests\TestCase;
@@ -19,21 +20,13 @@ class FetchChannelsTest extends TestCase
 
         $connection = new Connection();
 
-        $auth_key = 'TestKey';
-        $auth_timestamp = time();
-        $auth_version = '1.0';
+        $requestPath = '/apps/1234/channels';
 
-        $queryParameters = http_build_query(compact('auth_key', 'auth_timestamp', 'auth_version'));
+        $queryString = Pusher::build_auth_query_string('TestKey', 'InvalidSecret', 'GET', $requestPath, [
+            'appId' => '1234',
+        ]);
 
-        $signature =
-            "GET\n/apps/1234/channels\n".
-            "auth_key={$auth_key}".
-            "&auth_timestamp={$auth_timestamp}".
-            "&auth_version={$auth_version}";
-
-        $auth_signature = hash_hmac('sha256', $signature, 'InvalidSecret');
-
-        $request = new Request('GET', "/apps/1234/channels?appId=1234&auth_signature={$auth_signature}&{$queryParameters}");
+        $request = new Request('GET', "{$requestPath}?{$queryString}");
 
         $controller = app(FetchChannelsController::class);
 
@@ -49,21 +42,13 @@ class FetchChannelsTest extends TestCase
 
         $connection = new Connection();
 
-        $auth_key = 'TestKey';
-        $auth_timestamp = time();
-        $auth_version = '1.0';
+        $requestPath = '/apps/1234/channels';
 
-        $queryParameters = http_build_query(compact('auth_key', 'auth_timestamp', 'auth_version'));
+        $queryString = Pusher::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath, [
+            'appId' => '1234',
+        ]);
 
-        $signature =
-            "GET\n/apps/1234/channels\n".
-            "auth_key={$auth_key}".
-            "&auth_timestamp={$auth_timestamp}".
-            "&auth_version={$auth_version}";
-
-        $auth_signature = hash_hmac('sha256', $signature, 'TestSecret');
-
-        $request = new Request('GET', "/apps/1234/channels?appId=1234&auth_signature={$auth_signature}&{$queryParameters}");
+        $request = new Request('GET', "{$requestPath}?{$queryString}");
 
         $controller = app(FetchChannelsController::class);
 
@@ -91,22 +76,14 @@ class FetchChannelsTest extends TestCase
 
         $connection = new Connection();
 
-        $auth_key = 'TestKey';
-        $auth_timestamp = time();
-        $auth_version = '1.0';
+        $requestPath = '/apps/1234/channels';
 
-        $queryParameters = http_build_query(compact('auth_key', 'auth_timestamp', 'auth_version'));
+        $queryString = Pusher::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath, [
+            'appId'            => '1234',
+            'filter_by_prefix' => 'presence-global',
+        ]);
 
-        $signature =
-            "GET\n/apps/1234/channels\n".
-            'filter_by_prefix=presence-global' .
-            "auth_key={$auth_key}".
-            "&auth_timestamp={$auth_timestamp}".
-            "&auth_version={$auth_version}";
-
-        $auth_signature = hash_hmac('sha256', $signature, 'TestSecret');
-
-        $request = new Request('GET', "/apps/1234/channels?filter_by_prefix=presence-global&appId=1234&auth_signature={$auth_signature}&{$queryParameters}");
+        $request = new Request('GET', "{$requestPath}?{$queryString}");
 
         $controller = app(FetchChannelsController::class);
 

--- a/tests/HttpApi/FetchChannelsTest.php
+++ b/tests/HttpApi/FetchChannelsTest.php
@@ -21,12 +21,13 @@ class FetchChannelsTest extends TestCase
         $connection = new Connection();
 
         $requestPath = '/apps/1234/channels';
+        $routeParams = [
+            'appId' => '1234'
+        ];
 
-        $queryString = Pusher::build_auth_query_string('TestKey', 'InvalidSecret', 'GET', $requestPath, [
-            'appId' => '1234',
-        ]);
+        $queryString = Pusher::build_auth_query_string('TestKey', 'InvalidSecret', 'GET', $requestPath);
 
-        $request = new Request('GET', "{$requestPath}?{$queryString}");
+        $request = new Request('GET', "{$requestPath}?{$queryString}&".http_build_query($routeParams));
 
         $controller = app(FetchChannelsController::class);
 
@@ -43,12 +44,13 @@ class FetchChannelsTest extends TestCase
         $connection = new Connection();
 
         $requestPath = '/apps/1234/channels';
+        $routeParams = [
+            'appId' => '1234'
+        ];
 
-        $queryString = Pusher::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath, [
-            'appId' => '1234',
-        ]);
+        $queryString = Pusher::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath);
 
-        $request = new Request('GET', "{$requestPath}?{$queryString}");
+        $request = new Request('GET', "{$requestPath}?{$queryString}&".http_build_query($routeParams));
 
         $controller = app(FetchChannelsController::class);
 
@@ -77,13 +79,15 @@ class FetchChannelsTest extends TestCase
         $connection = new Connection();
 
         $requestPath = '/apps/1234/channels';
+        $routeParams = [
+            'appId' => '1234'
+        ];
 
         $queryString = Pusher::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath, [
-            'appId'            => '1234',
             'filter_by_prefix' => 'presence-global',
         ]);
 
-        $request = new Request('GET', "{$requestPath}?{$queryString}");
+        $request = new Request('GET', "{$requestPath}?{$queryString}&".http_build_query($routeParams));
 
         $controller = app(FetchChannelsController::class);
 

--- a/tests/HttpApi/FetchChannelsTest.php
+++ b/tests/HttpApi/FetchChannelsTest.php
@@ -22,7 +22,7 @@ class FetchChannelsTest extends TestCase
 
         $requestPath = '/apps/1234/channels';
         $routeParams = [
-            'appId' => '1234'
+            'appId' => '1234',
         ];
 
         $queryString = Pusher::build_auth_query_string('TestKey', 'InvalidSecret', 'GET', $requestPath);
@@ -45,7 +45,7 @@ class FetchChannelsTest extends TestCase
 
         $requestPath = '/apps/1234/channels';
         $routeParams = [
-            'appId' => '1234'
+            'appId' => '1234',
         ];
 
         $queryString = Pusher::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath);
@@ -80,7 +80,7 @@ class FetchChannelsTest extends TestCase
 
         $requestPath = '/apps/1234/channels';
         $routeParams = [
-            'appId' => '1234'
+            'appId' => '1234',
         ];
 
         $queryString = Pusher::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath, [

--- a/tests/HttpApi/FetchUsersTest.php
+++ b/tests/HttpApi/FetchUsersTest.php
@@ -20,13 +20,14 @@ class FetchUsersTest extends TestCase
         $connection = new Connection();
 
         $requestPath = '/apps/1234/channel/my-channel';
-
-        $queryString = Pusher::build_auth_query_string('TestKey', 'InvalidSecret', 'GET', $requestPath, [
+        $routeParams = [
             'appId' => '1234',
             'channelName' => 'my-channel',
-        ]);
+        ];
 
-        $request = new Request('GET', "{$requestPath}?{$queryString}");
+        $queryString = Pusher::build_auth_query_string('TestKey', 'InvalidSecret', 'GET', $requestPath);
+
+        $request = new Request('GET', "{$requestPath}?{$queryString}&".http_build_query($routeParams));
 
         $controller = app(FetchUsersController::class);
 
@@ -44,13 +45,14 @@ class FetchUsersTest extends TestCase
         $connection = new Connection();
 
         $requestPath = '/apps/1234/channel/my-channel/users';
-
-        $queryString = Pusher::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath, [
+        $routeParams = [
             'appId' => '1234',
             'channelName' => 'my-channel',
-        ]);
+        ];
 
-        $request = new Request('GET', "{$requestPath}?{$queryString}");
+        $queryString = Pusher::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath);
+
+        $request = new Request('GET', "{$requestPath}?{$queryString}&".http_build_query($routeParams));
 
         $controller = app(FetchUsersController::class);
 
@@ -68,13 +70,14 @@ class FetchUsersTest extends TestCase
         $connection = new Connection();
 
         $requestPath = '/apps/1234/channel/invalid-channel/users';
-
-        $queryString = Pusher::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath, [
+        $routeParams = [
             'appId' => '1234',
             'channelName' => 'invalid-channel',
-        ]);
+        ];
 
-        $request = new Request('GET', "{$requestPath}?{$queryString}");
+        $queryString = Pusher::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath);
+
+        $request = new Request('GET', "{$requestPath}?{$queryString}&".http_build_query($routeParams));
 
         $controller = app(FetchUsersController::class);
 
@@ -89,13 +92,14 @@ class FetchUsersTest extends TestCase
         $connection = new Connection();
 
         $requestPath = '/apps/1234/channel/presence-channel/users';
-
-        $queryString = Pusher::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath, [
+        $routeParams = [
             'appId' => '1234',
             'channelName' => 'presence-channel',
-        ]);
+        ];
 
-        $request = new Request('GET', "{$requestPath}?{$queryString}");
+        $queryString = Pusher::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath);
+
+        $request = new Request('GET', "{$requestPath}?{$queryString}&".http_build_query($routeParams));
 
         $controller = app(FetchUsersController::class);
 

--- a/tests/HttpApi/FetchUsersTest.php
+++ b/tests/HttpApi/FetchUsersTest.php
@@ -2,6 +2,7 @@
 
 namespace BeyondCode\LaravelWebSockets\Tests\HttpApi;
 
+use Pusher\Pusher;
 use GuzzleHttp\Psr7\Request;
 use BeyondCode\LaravelWebSockets\Tests\TestCase;
 use BeyondCode\LaravelWebSockets\Tests\Mocks\Connection;
@@ -18,21 +19,14 @@ class FetchUsersTest extends TestCase
 
         $connection = new Connection();
 
-        $auth_key = 'TestKey';
-        $auth_timestamp = time();
-        $auth_version = '1.0';
+        $requestPath = '/apps/1234/channel/my-channel';
 
-        $queryParameters = http_build_query(compact('auth_key', 'auth_timestamp', 'auth_version'));
+        $queryString = Pusher::build_auth_query_string('TestKey', 'InvalidSecret', 'GET', $requestPath, [
+            'appId' => '1234',
+            'channelName' => 'my-channel',
+        ]);
 
-        $signature =
-            "GET\n/apps/1234/channels\n".
-            "auth_key={$auth_key}".
-            "&auth_timestamp={$auth_timestamp}".
-            "&auth_version={$auth_version}";
-
-        $auth_signature = hash_hmac('sha256', $signature, 'InvalidSecret');
-
-        $request = new Request('GET', "/apps/1234/channel/my-channel?appId=1234&channelName=my-channel&auth_signature={$auth_signature}&{$queryParameters}");
+        $request = new Request('GET', "{$requestPath}?{$queryString}");
 
         $controller = app(FetchUsersController::class);
 
@@ -49,21 +43,14 @@ class FetchUsersTest extends TestCase
 
         $connection = new Connection();
 
-        $auth_key = 'TestKey';
-        $auth_timestamp = time();
-        $auth_version = '1.0';
+        $requestPath = '/apps/1234/channel/my-channel/users';
 
-        $queryParameters = http_build_query(compact('auth_key', 'auth_timestamp', 'auth_version'));
+        $queryString = Pusher::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath, [
+            'appId' => '1234',
+            'channelName' => 'my-channel',
+        ]);
 
-        $signature =
-            "GET\n/apps/1234/channel/my-channel/users\n".
-            "auth_key={$auth_key}".
-            "&auth_timestamp={$auth_timestamp}".
-            "&auth_version={$auth_version}";
-
-        $auth_signature = hash_hmac('sha256', $signature, 'TestSecret');
-
-        $request = new Request('GET', "/apps/1234/channel/my-channel/users?appId=1234&channelName=my-channel&auth_signature={$auth_signature}&{$queryParameters}");
+        $request = new Request('GET', "{$requestPath}?{$queryString}");
 
         $controller = app(FetchUsersController::class);
 
@@ -80,21 +67,14 @@ class FetchUsersTest extends TestCase
 
         $connection = new Connection();
 
-        $auth_key = 'TestKey';
-        $auth_timestamp = time();
-        $auth_version = '1.0';
+        $requestPath = '/apps/1234/channel/invalid-channel/users';
 
-        $queryParameters = http_build_query(compact('auth_key', 'auth_timestamp', 'auth_version'));
+        $queryString = Pusher::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath, [
+            'appId' => '1234',
+            'channelName' => 'invalid-channel',
+        ]);
 
-        $signature =
-            "GET\n/apps/1234/channel/my-channel/users\n".
-            "auth_key={$auth_key}".
-            "&auth_timestamp={$auth_timestamp}".
-            "&auth_version={$auth_version}";
-
-        $auth_signature = hash_hmac('sha256', $signature, 'TestSecret');
-
-        $request = new Request('GET', "/apps/1234/channel/my-channel/users?appId=1234&channelName=invalid-channel&auth_signature={$auth_signature}&{$queryParameters}");
+        $request = new Request('GET', "{$requestPath}?{$queryString}");
 
         $controller = app(FetchUsersController::class);
 
@@ -108,21 +88,14 @@ class FetchUsersTest extends TestCase
 
         $connection = new Connection();
 
-        $auth_key = 'TestKey';
-        $auth_timestamp = time();
-        $auth_version = '1.0';
+        $requestPath = '/apps/1234/channel/presence-channel/users';
 
-        $queryParameters = http_build_query(compact('auth_key', 'auth_timestamp', 'auth_version'));
+        $queryString = Pusher::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath, [
+            'appId' => '1234',
+            'channelName' => 'presence-channel',
+        ]);
 
-        $signature =
-            "GET\n/apps/1234/channel/my-channel/users\n".
-            "auth_key={$auth_key}".
-            "&auth_timestamp={$auth_timestamp}".
-            "&auth_version={$auth_version}";
-
-        $auth_signature = hash_hmac('sha256', $signature, 'TestSecret');
-
-        $request = new Request('GET', "/apps/1234/channel/my-channel/users?appId=1234&channelName=presence-channel&auth_signature={$auth_signature}&{$queryParameters}");
+        $request = new Request('GET', "{$requestPath}?{$queryString}");
 
         $controller = app(FetchUsersController::class);
 


### PR DESCRIPTION
I noticed that running this request to the websocket server yields an invalid signature error.

```php
$pusher->get_channels(['filter_by_prefix' => 'presence-global']);
```

I noticed that the signatures are not generated as the Pusher lib and server expects/validates them.

So I fixed that and modified all tests to use the correct way (according to the `Pusher` library).

----

Edit: After more testing this is broken since the route parameters are added as query params causing it to mess up the signature creation...

----

Edit edit: This now works like it should and ready for review