### PR TITLE
Fix Pusher lib expecting empty object not array

### DIFF
--- a/src/HttpApi/Controllers/FetchChannelsController.php
+++ b/src/HttpApi/Controllers/FetchChannelsController.php
@@ -25,7 +25,7 @@ class FetchChannelsController extends Controller
                 return [
                     'user_count' => count($channel->getUsers()),
                 ];
-            })->toArray(),
+            })->toArray() ?: new \stdClass,
         ];
     }
 }

--- a/tests/HttpApi/FetchChannelsTest.php
+++ b/tests/HttpApi/FetchChannelsTest.php
@@ -80,4 +80,35 @@ class FetchChannelsTest extends TestCase
             ],
         ], json_decode($response->getContent(), true));
     }
+
+    /** @test */
+    public function it_returns_empty_object_for_no_channels_found()
+    {
+        $connection = new Connection();
+
+        $auth_key = 'TestKey';
+        $auth_timestamp = time();
+        $auth_version = '1.0';
+
+        $queryParameters = http_build_query(compact('auth_key', 'auth_timestamp', 'auth_version'));
+
+        $signature =
+            "GET\n/apps/1234/channels\n".
+            "auth_key={$auth_key}".
+            "&auth_timestamp={$auth_timestamp}".
+            "&auth_version={$auth_version}";
+
+        $auth_signature = hash_hmac('sha256', $signature, 'TestSecret');
+
+        $request = new Request('GET', "/apps/1234/channels?appId=1234&auth_signature={$auth_signature}&{$queryParameters}");
+
+        $controller = app(FetchChannelsController::class);
+
+        $controller->onOpen($connection, $request);
+
+        /** @var JsonResponse $response */
+        $response = array_pop($connection->sentRawData);
+
+        $this->assertSame('{"channels":{}}', $response->getContent());
+    }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1090754/49668989-20dda080-fa60-11e8-9d98-d26efd35ce60.png)

^ without warnings are thrown if there are no channels (or the filtered query once it works returns no channels) because it expects `{"channels": {}}` instead of php encoding empty arrays as `{"channels": []}`.