### PR TITLE
Update ChannelManager

### DIFF
--- a/config/websockets.php
+++ b/config/websockets.php
@@ -94,6 +94,10 @@ return [
 
     /*
      * Channel Manager
+     * This class handles how channel persistence is handled.
+     * By default, persistence is stored in an array by the running webserver.
+     * The only requirement is that the class should implement
+     * `ChannelManager` interface provided by this package.
      */
     'channel_manager' => \BeyondCode\LaravelWebSockets\WebSockets\Channels\ChannelManagers\ArrayChannelManager::class,
 ];

--- a/config/websockets.php
+++ b/config/websockets.php
@@ -91,4 +91,9 @@ return [
          */
         'passphrase' => null,
     ],
+
+    /*
+     * Channel Manager
+     */
+    'channel_manager' => \BeyondCode\LaravelWebSockets\WebSockets\Channels\ChannelManagers\ArrayChannelManager::class,
 ];

--- a/src/WebSockets/Channels/ChannelManager.php
+++ b/src/WebSockets/Channels/ChannelManager.php
@@ -4,78 +4,15 @@ namespace BeyondCode\LaravelWebSockets\WebSockets\Channels;
 
 use Ratchet\ConnectionInterface;
 
-class ChannelManager
+interface ChannelManager
 {
-    /** @var string */
-    protected $appId;
+    public function findOrCreate(string $appId, string $channelName): Channel;
 
-    /** @var array */
-    protected $channels = [];
+    public function find(string $appId, string $channelName): ?Channel;
 
-    public function findOrCreate(string $appId, string $channelName): Channel
-    {
-        if (! isset($this->channels[$appId][$channelName])) {
-            $channelClass = $this->determineChannelClass($channelName);
+    public function getChannels(string $appId): array;
 
-            $this->channels[$appId][$channelName] = new $channelClass($channelName);
-        }
+    public function getConnectionCount(string $appId): int;
 
-        return $this->channels[$appId][$channelName];
-    }
-
-    public function find(string $appId, string $channelName): ?Channel
-    {
-        return $this->channels[$appId][$channelName] ?? null;
-    }
-
-    protected function determineChannelClass(string $channelName): string
-    {
-        if (starts_with($channelName, 'private-')) {
-            return PrivateChannel::class;
-        }
-
-        if (starts_with($channelName, 'presence-')) {
-            return PresenceChannel::class;
-        }
-
-        return Channel::class;
-    }
-
-    public function getChannels(string $appId): array
-    {
-        return $this->channels[$appId] ?? [];
-    }
-
-    public function getConnectionCount(string $appId): int
-    {
-        return collect($this->getChannels($appId))
-            ->sum(function ($channel) {
-                return count($channel->getSubscribedConnections());
-            });
-    }
-
-    public function removeFromAllChannels(ConnectionInterface $connection)
-    {
-        if (! isset($connection->app)) {
-            return;
-        }
-
-        /*
-         * Remove the connection from all channels.
-         */
-        collect(array_get($this->channels, $connection->app->id, []))->each->unsubscribe($connection);
-
-        /*
-         * Unset all channels that have no connections so we don't leak memory.
-         */
-        collect(array_get($this->channels, $connection->app->id, []))
-            ->reject->hasConnections()
-            ->each(function (Channel $channel, string $channelName) use ($connection) {
-                unset($this->channels[$connection->app->id][$channelName]);
-            });
-
-        if (count(array_get($this->channels, $connection->app->id, [])) === 0) {
-            unset($this->channels[$connection->app->id]);
-        }
-    }
+    public function removeFromAllChannels(ConnectionInterface $connection);
 }

--- a/src/WebSockets/Channels/ChannelManagers/ArrayChannelManager.php
+++ b/src/WebSockets/Channels/ChannelManagers/ArrayChannelManager.php
@@ -8,7 +8,6 @@ use BeyondCode\LaravelWebSockets\WebSockets\Channels\ChannelManager;
 use BeyondCode\LaravelWebSockets\WebSockets\Channels\PrivateChannel;
 use BeyondCode\LaravelWebSockets\WebSockets\Channels\PresenceChannel;
 
-
 class ArrayChannelManager implements ChannelManager
 {
     /** @var string */

--- a/src/WebSockets/Channels/ChannelManagers/ArrayChannelManager.php
+++ b/src/WebSockets/Channels/ChannelManagers/ArrayChannelManager.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace BeyondCode\LaravelWebSockets\WebSockets\Channels\ChannelManagers;
+
+use BeyondCode\LaravelWebSockets\WebSockets\Channels\Channel;
+use BeyondCode\LaravelWebSockets\WebSockets\Channels\ChannelManager;
+use BeyondCode\LaravelWebSockets\WebSockets\Channels\PresenceChannel;
+use BeyondCode\LaravelWebSockets\WebSockets\Channels\PrivateChannel;
+use Ratchet\ConnectionInterface;
+
+class ArrayChannelManager implements ChannelManager
+{
+    /** @var string */
+    protected $appId;
+
+    /** @var array */
+    protected $channels = [];
+
+    public function findOrCreate(string $appId, string $channelName): Channel
+    {
+        if (! isset($this->channels[$appId][$channelName])) {
+            $channelClass = $this->determineChannelClass($channelName);
+
+            $this->channels[$appId][$channelName] = new $channelClass($channelName);
+        }
+
+        return $this->channels[$appId][$channelName];
+    }
+
+    public function find(string $appId, string $channelName): ?Channel
+    {
+        return $this->channels[$appId][$channelName] ?? null;
+    }
+
+    protected function determineChannelClass(string $channelName): string
+    {
+        if (starts_with($channelName, 'private-')) {
+            return PrivateChannel::class;
+        }
+
+        if (starts_with($channelName, 'presence-')) {
+            return PresenceChannel::class;
+        }
+
+        return Channel::class;
+    }
+
+    public function getChannels(string $appId): array
+    {
+        return $this->channels[$appId] ?? [];
+    }
+
+    public function getConnectionCount(string $appId): int
+    {
+        return collect($this->getChannels($appId))
+            ->sum(function ($channel) {
+                return count($channel->getSubscribedConnections());
+            });
+    }
+
+    public function removeFromAllChannels(ConnectionInterface $connection)
+    {
+        if (! isset($connection->app)) {
+            return;
+        }
+
+        /*
+         * Remove the connection from all channels.
+         */
+        collect(array_get($this->channels, $connection->app->id, []))->each->unsubscribe($connection);
+
+        /*
+         * Unset all channels that have no connections so we don't leak memory.
+         */
+        collect(array_get($this->channels, $connection->app->id, []))
+            ->reject->hasConnections()
+                    ->each(function (Channel $channel, string $channelName) use ($connection) {
+                        unset($this->channels[$connection->app->id][$channelName]);
+                    });
+
+        if (count(array_get($this->channels, $connection->app->id, [])) === 0) {
+            unset($this->channels[$connection->app->id]);
+        }
+    }
+}

--- a/src/WebSockets/Channels/ChannelManagers/ArrayChannelManager.php
+++ b/src/WebSockets/Channels/ChannelManagers/ArrayChannelManager.php
@@ -2,11 +2,12 @@
 
 namespace BeyondCode\LaravelWebSockets\WebSockets\Channels\ChannelManagers;
 
+use Ratchet\ConnectionInterface;
 use BeyondCode\LaravelWebSockets\WebSockets\Channels\Channel;
 use BeyondCode\LaravelWebSockets\WebSockets\Channels\ChannelManager;
-use BeyondCode\LaravelWebSockets\WebSockets\Channels\PresenceChannel;
 use BeyondCode\LaravelWebSockets\WebSockets\Channels\PrivateChannel;
-use Ratchet\ConnectionInterface;
+use BeyondCode\LaravelWebSockets\WebSockets\Channels\PresenceChannel;
+
 
 class ArrayChannelManager implements ChannelManager
 {

--- a/src/WebSocketsServiceProvider.php
+++ b/src/WebSocketsServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace BeyondCode\LaravelWebSockets;
 
-use BeyondCode\LaravelWebSockets\WebSockets\Channels\ChannelManagers\ArrayChannelManager;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
@@ -13,6 +12,7 @@ use BeyondCode\LaravelWebSockets\Dashboard\Http\Controllers\SendMessage;
 use BeyondCode\LaravelWebSockets\Dashboard\Http\Controllers\ShowDashboard;
 use BeyondCode\LaravelWebSockets\Dashboard\Http\Controllers\AuthenticateDashboard;
 use BeyondCode\LaravelWebSockets\Dashboard\Http\Controllers\DashboardApiController;
+use BeyondCode\LaravelWebSockets\WebSockets\Channels\ChannelManagers\ArrayChannelManager;
 use BeyondCode\LaravelWebSockets\Dashboard\Http\Middleware\Authorize as AuthorizeDashboard;
 use BeyondCode\LaravelWebSockets\Statistics\Http\Middleware\Authorize as AuthorizeStatistics;
 use BeyondCode\LaravelWebSockets\Statistics\Http\Controllers\WebSocketStatisticsEntriesController;

--- a/src/WebSocketsServiceProvider.php
+++ b/src/WebSocketsServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace BeyondCode\LaravelWebSockets;
 
+use BeyondCode\LaravelWebSockets\WebSockets\Channels\ChannelManagers\ArrayChannelManager;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
@@ -51,7 +52,8 @@ class WebSocketsServiceProvider extends ServiceProvider
         });
 
         $this->app->singleton(ChannelManager::class, function () {
-            return app(config('websockets.channel_manager'));
+            return config('websockets.channel_manager') !== null && class_exists(config('websockets.channel_manager'))
+                ? app(config('websockets.channel_manager')) : new ArrayChannelManager();
         });
 
         $this->app->singleton(AppProvider::class, function () {

--- a/src/WebSocketsServiceProvider.php
+++ b/src/WebSocketsServiceProvider.php
@@ -51,7 +51,7 @@ class WebSocketsServiceProvider extends ServiceProvider
         });
 
         $this->app->singleton(ChannelManager::class, function () {
-            return new ChannelManager();
+            return app(config('websockets.channel_manager'));
         });
 
         $this->app->singleton(AppProvider::class, function () {


### PR DESCRIPTION
In reference to #6. The idea will eventually be to create additional channel managers. A good first start is allowing the user to swap the channel manager.

This commit:
- Switches ChannelManager to an interface. 
- Moves old ChannelManager to a new ArrayChannelManager which implements the new ChannelManager interface.
- Updates the config to allow for swapping. 
- Binds it to the ServiceProvider.

By turning ChannelManager into an interface, we keep compatibility with type hints everywhere else.

My only concern is adding something new the config, which people wouldn't have if they've already published it. Maybe I should fallback? Not sure what the best step forward is.

All the tests currently pass, but happy to add more tests if we'd like something specific tested. I'll be adding tests once I dig into implementing a new RedisChannelManager in a separate PR