### PR TITLE
Added MemberAdded and MemberRemoved events for presence channels

### DIFF
--- a/src/Events/MemberAdded.php
+++ b/src/Events/MemberAdded.php
@@ -10,6 +10,6 @@ class MemberAdded
     public function __construct($channel, $data)
     {
         $this->channel = $channel;
-        $this->data    = $data;
+        $this->data = $data;
     }
 }

--- a/src/Events/MemberAdded.php
+++ b/src/Events/MemberAdded.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace BeyondCode\LaravelWebSockets\Events;
+
+class MemberAdded
+{
+    public $channel;
+    public $data;
+
+    public function __construct($channel, $data)
+    {
+        $this->channel = $channel;
+        $this->data    = $data;
+    }
+}

--- a/src/Events/MemberRemoved.php
+++ b/src/Events/MemberRemoved.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace BeyondCode\LaravelWebSockets\Events;
+
+class MemberRemoved
+{
+    public $channel;
+    public $data;
+
+    public function __construct($channel, $data)
+    {
+        $this->channel = $channel;
+        $this->data    = $data;
+    }
+}

--- a/src/Events/MemberRemoved.php
+++ b/src/Events/MemberRemoved.php
@@ -10,6 +10,6 @@ class MemberRemoved
     public function __construct($channel, $data)
     {
         $this->channel = $channel;
-        $this->data    = $data;
+        $this->data = $data;
     }
 }

--- a/src/WebSockets/Channels/PresenceChannel.php
+++ b/src/WebSockets/Channels/PresenceChannel.php
@@ -2,10 +2,10 @@
 
 namespace BeyondCode\LaravelWebSockets\WebSockets\Channels;
 
+use stdClass;
+use Ratchet\ConnectionInterface;
 use BeyondCode\LaravelWebSockets\Events\MemberAdded;
 use BeyondCode\LaravelWebSockets\Events\MemberRemoved;
-use Ratchet\ConnectionInterface;
-use stdClass;
 
 class PresenceChannel extends Channel
 {
@@ -25,7 +25,7 @@ class PresenceChannel extends Channel
 
         $this->saveConnection($connection);
 
-        $channelData                        = json_decode($payload->channel_data);
+        $channelData = json_decode($payload->channel_data);
         $this->users[$connection->socketId] = $channelData;
 
         // Send the success event
@@ -48,7 +48,7 @@ class PresenceChannel extends Channel
     {
         parent::unsubscribe($connection);
 
-        if (!isset($this->users[$connection->socketId])) {
+        if (! isset($this->users[$connection->socketId])) {
             return;
         }
 

--- a/tests/Channels/PresenceChannelTest.php
+++ b/tests/Channels/PresenceChannelTest.php
@@ -2,9 +2,12 @@
 
 namespace BeyondCode\LaravelWebSockets\Tests\Channels;
 
-use BeyondCode\LaravelWebSockets\Tests\TestCase;
+use BeyondCode\LaravelWebSockets\Events\MemberAdded;
+use BeyondCode\LaravelWebSockets\Events\MemberRemoved;
 use BeyondCode\LaravelWebSockets\Tests\Mocks\Message;
+use BeyondCode\LaravelWebSockets\Tests\TestCase;
 use BeyondCode\LaravelWebSockets\WebSockets\Exceptions\InvalidSignature;
+use Illuminate\Support\Facades\Event;
 
 class PresenceChannelTest extends TestCase
 {
@@ -17,8 +20,8 @@ class PresenceChannelTest extends TestCase
 
         $message = new Message(json_encode([
             'event' => 'pusher:subscribe',
-            'data' => [
-                'auth' => 'invalid',
+            'data'  => [
+                'auth'    => 'invalid',
                 'channel' => 'presence-channel',
             ],
         ]));
@@ -31,24 +34,26 @@ class PresenceChannelTest extends TestCase
     /** @test */
     public function clients_with_valid_auth_signatures_can_join_presence_channels()
     {
+        Event::fake();
+
         $connection = $this->getWebSocketConnection();
 
         $this->pusherServer->onOpen($connection);
 
         $channelData = [
-            'user_id' => 1,
+            'user_id'   => 1,
             'user_info' => [
                 'name' => 'Marcel',
             ],
         ];
 
-        $signature = "{$connection->socketId}:presence-channel:".json_encode($channelData);
+        $signature = "{$connection->socketId}:presence-channel:" . json_encode($channelData);
 
         $message = new Message(json_encode([
             'event' => 'pusher:subscribe',
-            'data' => [
-                'auth' => $connection->app->key.':'.hash_hmac('sha256', $signature, $connection->app->secret),
-                'channel' => 'presence-channel',
+            'data'  => [
+                'auth'         => $connection->app->key . ':' . hash_hmac('sha256', $signature, $connection->app->secret),
+                'channel'      => 'presence-channel',
                 'channel_data' => json_encode($channelData),
             ],
         ]));
@@ -58,5 +63,33 @@ class PresenceChannelTest extends TestCase
         $connection->assertSentEvent('pusher_internal:subscription_succeeded', [
             'channel' => 'presence-channel',
         ]);
+
+        Event::assertDispatched(MemberAdded::class, function ($event) use ($channelData) {
+            return $event->channel === 'presence-channel' &&
+            $event->data == json_decode(json_encode($channelData));
+        });
+    }
+
+    /** @test */
+    public function clients_can_unsubscribe_from_channels()
+    {
+        Event::fake();
+
+        $connection = $this->joinPresenceChannel('presence-channel');
+
+        $channel = $this->getChannel($connection, 'presence-channel');
+
+        $message = new Message(json_encode([
+            'event' => 'pusher:unsubscribe',
+            'data'  => [
+                'channel' => 'presence-channel',
+            ],
+        ]));
+
+        $this->pusherServer->onMessage($connection, $message);
+
+        Event::assertDispatched(MemberRemoved::class, function ($event) {
+            return $event->channel === 'presence-channel' && $event->data == ['user_id' => 1];
+        });
     }
 }

--- a/tests/Channels/PresenceChannelTest.php
+++ b/tests/Channels/PresenceChannelTest.php
@@ -2,12 +2,12 @@
 
 namespace BeyondCode\LaravelWebSockets\Tests\Channels;
 
-use BeyondCode\LaravelWebSockets\Events\MemberAdded;
-use BeyondCode\LaravelWebSockets\Events\MemberRemoved;
-use BeyondCode\LaravelWebSockets\Tests\Mocks\Message;
-use BeyondCode\LaravelWebSockets\Tests\TestCase;
-use BeyondCode\LaravelWebSockets\WebSockets\Exceptions\InvalidSignature;
 use Illuminate\Support\Facades\Event;
+use BeyondCode\LaravelWebSockets\Tests\TestCase;
+use BeyondCode\LaravelWebSockets\Events\MemberAdded;
+use BeyondCode\LaravelWebSockets\Tests\Mocks\Message;
+use BeyondCode\LaravelWebSockets\Events\MemberRemoved;
+use BeyondCode\LaravelWebSockets\WebSockets\Exceptions\InvalidSignature;
 
 class PresenceChannelTest extends TestCase
 {
@@ -47,12 +47,12 @@ class PresenceChannelTest extends TestCase
             ],
         ];
 
-        $signature = "{$connection->socketId}:presence-channel:" . json_encode($channelData);
+        $signature = "{$connection->socketId}:presence-channel:".json_encode($channelData);
 
         $message = new Message(json_encode([
             'event' => 'pusher:subscribe',
             'data'  => [
-                'auth'         => $connection->app->key . ':' . hash_hmac('sha256', $signature, $connection->app->secret),
+                'auth'         => $connection->app->key.':'.hash_hmac('sha256', $signature, $connection->app->secret),
                 'channel'      => 'presence-channel',
                 'channel_data' => json_encode($channelData),
             ],


### PR DESCRIPTION
Example usage: a listener that saves to the DB whenever a member leaves a presence channel.