### PR TITLE
[WIP] Add batch_events HTTP API endpoint

### DIFF
--- a/src/HttpApi/Controllers/Concerns/BroadcastsEvents.php
+++ b/src/HttpApi/Controllers/Concerns/BroadcastsEvents.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace BeyondCode\LaravelWebSockets\HttpApi\Controllers\Concerns;
+
+trait BroadcastsEvents
+{
+    protected function broadcastEventForAppToChannel($appId, $channelName, $event, $data, $socketId = null): void
+    {
+        $channel = $this->channelManager->find($appId, $channelName);
+
+        optional($channel)->broadcastToEveryoneExcept([
+            'channel' => $channelName,
+            'event' => $event,
+            'data' => $data,
+        ], $socketId);
+
+        DashboardLogger::apiMessage(
+            $appId,
+            $channelName,
+            $event,
+            $data
+        );
+
+        StatisticsLogger::apiMessage($appId);
+    }
+}

--- a/src/HttpApi/Controllers/Controller.php
+++ b/src/HttpApi/Controllers/Controller.php
@@ -44,7 +44,7 @@ abstract class Controller implements HttpServerInterface
 
         $response = $this($laravelRequest);
 
-        $connection->send(JsonResponse::create($response));
+        $connection->send($response instanceof JsonResponse ? $response : JsonResponse::create($response));
         $connection->close();
     }
 

--- a/src/HttpApi/Controllers/TriggerBatchedEventsController.php
+++ b/src/HttpApi/Controllers/TriggerBatchedEventsController.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace BeyondCode\LaravelWebSockets\HttpApi\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+use BeyondCode\LaravelWebSockets\HttpApi\Controllers\Concerns\BroadcastsEvents;
+
+class TriggerBatchedEventsController extends Controller
+{
+    use BroadcastsEvents;
+
+    public function __invoke(Request $request)
+    {
+        $this->ensureValidSignature($request);
+
+        $validator = validator($request->json()->all(), [
+            'batch.*.name' => 'required',
+            'batch.*.data' => 'required',
+            'batch.*.channel' => 'required',
+        ], [
+            'required' => 'Missing required parameter: :attribute',
+        ]);
+
+        if ($validator->fails()) {
+            return new JsonResponse([
+                'body' => 'Failed input validation.',
+                'status' => 400,
+                'validation_errors' => $validator->errors()->toArray(),
+            ], 400);
+        }
+
+        foreach ($request->json()->get('batch', []) as $event) {
+            $this->broadcastEventForAppToChannel(
+                $request->appId,
+                $event['channel'],
+                $event['name'],
+                $event['data'],
+                $event['socket_id'] ?? null
+            );
+        }
+
+        return $request->json()->all();
+    }
+}

--- a/src/HttpApi/Controllers/TriggerEventController.php
+++ b/src/HttpApi/Controllers/TriggerEventController.php
@@ -3,32 +3,24 @@
 namespace BeyondCode\LaravelWebSockets\HttpApi\Controllers;
 
 use Illuminate\Http\Request;
-use BeyondCode\LaravelWebSockets\Facades\StatisticsLogger;
-use BeyondCode\LaravelWebSockets\Dashboard\DashboardLogger;
+use BeyondCode\LaravelWebSockets\HttpApi\Controllers\Concerns\BroadcastsEvents;
 
 class TriggerEventController extends Controller
 {
+    use BroadcastsEvents;
+
     public function __invoke(Request $request)
     {
         $this->ensureValidSignature($request);
 
         foreach ($request->json()->get('channels', []) as $channelName) {
-            $channel = $this->channelManager->find($request->appId, $channelName);
-
-            optional($channel)->broadcastToEveryoneExcept([
-                'channel' => $channelName,
-                'event' => $request->json()->get('name'),
-                'data' => $request->json()->get('data'),
-            ], $request->json()->get('socket_id'));
-
-            DashboardLogger::apiMessage(
+            $this->broadcastEventForAppToChannel(
                 $request->appId,
                 $channelName,
                 $request->json()->get('name'),
-                $request->json()->get('data')
+                $request->json()->get('data'),
+                $request->json()->get('socket_id')
             );
-
-            StatisticsLogger::apiMessage($request->appId);
         }
 
         return $request->json()->all();

--- a/src/Server/Router.php
+++ b/src/Server/Router.php
@@ -13,6 +13,7 @@ use BeyondCode\LaravelWebSockets\HttpApi\Controllers\FetchUsersController;
 use BeyondCode\LaravelWebSockets\HttpApi\Controllers\FetchChannelController;
 use BeyondCode\LaravelWebSockets\HttpApi\Controllers\TriggerEventController;
 use BeyondCode\LaravelWebSockets\HttpApi\Controllers\FetchChannelsController;
+use BeyondCode\LaravelWebSockets\HttpApi\Controllers\TriggerBatchedEventsController;
 
 class Router
 {
@@ -35,6 +36,7 @@ class Router
 
         $this->post('/apps/{appId}/events', TriggerEventController::class);
         $this->get('/apps/{appId}/channels', FetchChannelsController::class);
+        $this->post('/apps/{appId}/batch_events', TriggerBatchedEventsController::class);
         $this->get('/apps/{appId}/channels/{channelName}', FetchChannelController::class);
         $this->get('/apps/{appId}/channels/{channelName}/users', FetchUsersController::class);
     }


### PR DESCRIPTION
This adds the [`/apps/[app_id]/batch_events`](https://pusher.com/docs/rest_api#method-post-batch-events) endpoint.

`WIP`: because this add some validation I would first like to be reviewed or nudged in doing it another way if that's better/more acceptable. (no tests yet too)

I am using a "custom" JsonResponse to stay as close a possible to the Pusher API response and only add an extra field in the response with the validation errors.

Pusher responds with something like the response below. As far as I can tell they only report the first error and does not send any remaining valid events, so I matched that here.

```json
{
    "body": "Missing required parameter: channel\n",
    "status": 400,
}
```

I also want to add this validation to the `TriggerEventController` if the way of doing this validation is correct or we land on a good validation method.