### PR TITLE
Add support for Laravel 5.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,18 +27,19 @@
         "cboden/ratchet": "^0.4.1",
         "clue/buzz-react": "^2.5",
         "guzzlehttp/psr7": "^1.5",
-        "illuminate/broadcasting": "5.7.*",
-        "illuminate/console": "5.7.*",
-        "illuminate/http": "5.7.*",
-        "illuminate/routing": "5.7.*",
-        "illuminate/support": "5.7.*",
+        "illuminate/broadcasting": "5.7.* || 5.8.*",
+        "illuminate/console": "5.7.* || 5.8.*",
+        "illuminate/http": "5.7.* || 5.8.*",
+        "illuminate/routing": "5.7.* || 5.8.*",
+        "illuminate/support": "5.7.* || 5.8.*",
         "pusher/pusher-php-server": "~3.0",
         "symfony/http-kernel": "~4.0",
         "symfony/psr-http-message-bridge": "^1.1"
     },
     "require-dev": {
         "mockery/mockery": "^1.2",
-        "orchestra/testbench": "3.7.*",
+        "orchestra/testbench": "3.7.* || 3.8.*",
+        "orchestra/testbench-core": "3.7.* || 3.8.* || 3.8.x-dev",
         "phpunit/phpunit": "^7.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,6 @@
     "require-dev": {
         "mockery/mockery": "^1.2",
         "orchestra/testbench": "3.7.* || 3.8.*",
-        "orchestra/testbench-core": "3.7.* || 3.8.* || 3.8.x-dev",
         "phpunit/phpunit": "^7.0"
     },
     "autoload": {

--- a/src/HttpApi/Controllers/Controller.php
+++ b/src/HttpApi/Controllers/Controller.php
@@ -4,6 +4,7 @@ namespace BeyondCode\LaravelWebSockets\HttpApi\Controllers;
 
 use Exception;
 use Pusher\Pusher;
+use Illuminate\Support\Arr;
 use Illuminate\Http\Request;
 use GuzzleHttp\Psr7\Response;
 use Ratchet\ConnectionInterface;
@@ -90,7 +91,7 @@ abstract class Controller implements HttpServerInterface
          *
          * The `appId`, `appKey` & `channelName` parameters are actually route paramaters and are never supplied by the client.
          */
-        $params = array_except($request->query(), ['auth_signature', 'body_md5', 'appId', 'appKey', 'channelName']);
+        $params = Arr::except($request->query(), ['auth_signature', 'body_md5', 'appId', 'appKey', 'channelName']);
 
         if ($request->getContent() !== '') {
             $params['body_md5'] = md5($request->getContent());

--- a/src/HttpApi/Controllers/FetchChannelsController.php
+++ b/src/HttpApi/Controllers/FetchChannelsController.php
@@ -2,6 +2,7 @@
 
 namespace BeyondCode\LaravelWebSockets\HttpApi\Controllers;
 
+use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use BeyondCode\LaravelWebSockets\WebSockets\Channels\PresenceChannel;
@@ -16,7 +17,7 @@ class FetchChannelsController extends Controller
 
         if ($request->has('filter_by_prefix')) {
             $channels = $channels->filter(function ($channel, $channelName) use ($request) {
-                return starts_with($channelName, $request->filter_by_prefix);
+                return Str::startsWith($channelName, $request->filter_by_prefix);
             });
         }
 

--- a/src/Statistics/Events/StatisticsUpdated.php
+++ b/src/Statistics/Events/StatisticsUpdated.php
@@ -2,6 +2,7 @@
 
 namespace BeyondCode\LaravelWebSockets\Statistics\Events;
 
+use Illuminate\Support\Str;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Broadcasting\PrivateChannel;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
@@ -33,7 +34,7 @@ class StatisticsUpdated implements ShouldBroadcast
 
     public function broadcastOn()
     {
-        $channelName = str_after(DashboardLogger::LOG_CHANNEL_PREFIX.'statistics', 'private-');
+        $channelName = Str::after(DashboardLogger::LOG_CHANNEL_PREFIX.'statistics', 'private-');
 
         return new PrivateChannel($channelName);
     }

--- a/src/WebSockets/Channels/Channel.php
+++ b/src/WebSockets/Channels/Channel.php
@@ -3,6 +3,7 @@
 namespace BeyondCode\LaravelWebSockets\WebSockets\Channels;
 
 use stdClass;
+use Illuminate\Support\Str;
 use Ratchet\ConnectionInterface;
 use BeyondCode\LaravelWebSockets\Dashboard\DashboardLogger;
 use BeyondCode\LaravelWebSockets\WebSockets\Exceptions\InvalidSignature;
@@ -38,7 +39,7 @@ class Channel
             $signature .= ":{$payload->channel_data}";
         }
 
-        if (str_after($payload->auth, ':') !== hash_hmac('sha256', $signature, $connection->app->secret)) {
+        if (Str::after($payload->auth, ':') !== hash_hmac('sha256', $signature, $connection->app->secret)) {
             throw new InvalidSignature();
         }
     }

--- a/src/WebSockets/Channels/ChannelManagers/ArrayChannelManager.php
+++ b/src/WebSockets/Channels/ChannelManagers/ArrayChannelManager.php
@@ -2,6 +2,8 @@
 
 namespace BeyondCode\LaravelWebSockets\WebSockets\Channels\ChannelManagers;
 
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use Ratchet\ConnectionInterface;
 use BeyondCode\LaravelWebSockets\WebSockets\Channels\Channel;
 use BeyondCode\LaravelWebSockets\WebSockets\Channels\ChannelManager;
@@ -34,11 +36,11 @@ class ArrayChannelManager implements ChannelManager
 
     protected function determineChannelClass(string $channelName): string
     {
-        if (starts_with($channelName, 'private-')) {
+        if (Str::startsWith($channelName, 'private-')) {
             return PrivateChannel::class;
         }
 
-        if (starts_with($channelName, 'presence-')) {
+        if (Str::startsWith($channelName, 'presence-')) {
             return PresenceChannel::class;
         }
 
@@ -67,18 +69,18 @@ class ArrayChannelManager implements ChannelManager
         /*
          * Remove the connection from all channels.
          */
-        collect(array_get($this->channels, $connection->app->id, []))->each->unsubscribe($connection);
+        collect(Arr::get($this->channels, $connection->app->id, []))->each->unsubscribe($connection);
 
         /*
          * Unset all channels that have no connections so we don't leak memory.
          */
-        collect(array_get($this->channels, $connection->app->id, []))
+        collect(Arr::get($this->channels, $connection->app->id, []))
             ->reject->hasConnections()
                     ->each(function (Channel $channel, string $channelName) use ($connection) {
                         unset($this->channels[$connection->app->id][$channelName]);
                     });
 
-        if (count(array_get($this->channels, $connection->app->id, [])) === 0) {
+        if (count(Arr::get($this->channels, $connection->app->id, [])) === 0) {
             unset($this->channels[$connection->app->id]);
         }
     }

--- a/src/WebSockets/Messages/PusherChannelProtocolMessage.php
+++ b/src/WebSockets/Messages/PusherChannelProtocolMessage.php
@@ -3,6 +3,7 @@
 namespace BeyondCode\LaravelWebSockets\WebSockets\Messages;
 
 use stdClass;
+use Illuminate\Support\Str;
 use Ratchet\ConnectionInterface;
 use BeyondCode\LaravelWebSockets\WebSockets\Channels\ChannelManager;
 
@@ -28,7 +29,7 @@ class PusherChannelProtocolMessage implements PusherMessage
 
     public function respond()
     {
-        $eventName = camel_case(str_after($this->payload->event, ':'));
+        $eventName = Str::camel(Str::after($this->payload->event, ':'));
 
         if (method_exists($this, $eventName)) {
             call_user_func([$this, $eventName], $this->connection, $this->payload->data ?? new stdClass());

--- a/src/WebSockets/Messages/PusherClientMessage.php
+++ b/src/WebSockets/Messages/PusherClientMessage.php
@@ -3,6 +3,7 @@
 namespace BeyondCode\LaravelWebSockets\WebSockets\Messages;
 
 use stdClass;
+use Illuminate\Support\Str;
 use Ratchet\ConnectionInterface;
 use BeyondCode\LaravelWebSockets\Dashboard\DashboardLogger;
 use BeyondCode\LaravelWebSockets\WebSockets\Channels\ChannelManager;
@@ -29,7 +30,7 @@ class PusherClientMessage implements PusherMessage
 
     public function respond()
     {
-        if (! starts_with($this->payload->event, 'client-')) {
+        if (! Str::startsWith($this->payload->event, 'client-')) {
             return;
         }
 

--- a/src/WebSockets/Messages/PusherMessageFactory.php
+++ b/src/WebSockets/Messages/PusherMessageFactory.php
@@ -2,6 +2,7 @@
 
 namespace BeyondCode\LaravelWebSockets\WebSockets\Messages;
 
+use Illuminate\Support\Str;
 use Ratchet\ConnectionInterface;
 use Ratchet\RFC6455\Messaging\MessageInterface;
 use BeyondCode\LaravelWebSockets\WebSockets\Channels\ChannelManager;
@@ -15,7 +16,7 @@ class PusherMessageFactory
     {
         $payload = json_decode($message->getPayload());
 
-        return starts_with($payload->event, 'pusher:')
+        return Str::startsWith($payload->event, 'pusher:')
             ? new PusherChannelProtocolMessage($payload, $connection, $channelManager)
             : new PusherClientMessage($payload, $connection, $channelManager);
     }

--- a/tests/ClientProviders/ConfigAppProviderTest.php
+++ b/tests/ClientProviders/ConfigAppProviderTest.php
@@ -10,7 +10,7 @@ class ConfigAppProviderTest extends TestCase
     /** @var \BeyondCode\LaravelWebSockets\Apps\ConfigAppProvider */
     protected $configAppProvider;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Commands/CleanStatisticsTest.php
+++ b/tests/Commands/CleanStatisticsTest.php
@@ -10,7 +10,7 @@ use BeyondCode\LaravelWebSockets\Statistics\Models\WebSocketsStatisticsEntry;
 
 class CleanStatisticsTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -19,7 +19,7 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
     /** @var \BeyondCode\LaravelWebSockets\WebSockets\Channels\ChannelManager */
     protected $channelManager;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
- Added support for `5.8.*` illuminate dependencies.
- Added support for `3.8.*` orchestra/testbench dependency
- ~NOTE: I needed to add `orchestra/testbench-core` as a dependency for now because a release wasn't tagged yet. See https://github.com/orchestral/testbench-core/issues/21. That line can be removed as soon as a release is tagged.~ This change is no longer needed, release was tagged.
- Add `: void` on test `setUp()` due to it being required by orchestra/testbench 3.8 (PHPUnit 8 compatibility change)
- Removed deprecated `array_` and `str_` global helpers (~I think I got them all, but I'm not 100% sure~ Thanks Scrutinizer for telling me the ones I missed! :tada:)

Fixes #119 