### PR TITLE
Fixed channels HTTP API endpoint

### DIFF
--- a/src/HttpApi/Controllers/FetchChannelsController.php
+++ b/src/HttpApi/Controllers/FetchChannelsController.php
@@ -11,14 +11,6 @@ class FetchChannelsController extends Controller
 {
     public function __invoke(Request $request)
     {
-        $channels = Collection::make($this->channelManager->getChannels($request->appId));
-
-        if ($request->has('filter_by_prefix')) {
-            $channels = $channels->filter(function ($channel, $channelName) use ($request) {
-                return Str::startsWith($channelName, $request->filter_by_prefix);
-            });
-        }
-
         $attributes = [];
 
         if ($request->has('info')) {
@@ -27,6 +19,14 @@ class FetchChannelsController extends Controller
             if (in_array('user_count', $attributes) && ! Str::startsWith($request->filter_by_prefix, 'presence-')) {
                 throw new HttpException(400, 'Request must be limited to presence channels in order to fetch user_count');
             }
+        }
+
+        $channels = Collection::make($this->channelManager->getChannels($request->appId));
+
+        if ($request->has('filter_by_prefix')) {
+            $channels = $channels->filter(function ($channel, $channelName) use ($request) {
+                return Str::startsWith($channelName, $request->filter_by_prefix);
+            });
         }
 
         return [

--- a/src/HttpApi/Controllers/FetchChannelsController.php
+++ b/src/HttpApi/Controllers/FetchChannelsController.php
@@ -5,15 +5,14 @@ namespace BeyondCode\LaravelWebSockets\HttpApi\Controllers;
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use BeyondCode\LaravelWebSockets\WebSockets\Channels\PresenceChannel;
 
 class FetchChannelsController extends Controller
 {
     public function __invoke(Request $request)
     {
-        $channels = Collection::make($this->channelManager->getChannels($request->appId))->filter(function ($channel) {
-            return $channel instanceof PresenceChannel;
-        });
+        $channels = Collection::make($this->channelManager->getChannels($request->appId));
 
         if ($request->has('filter_by_prefix')) {
             $channels = $channels->filter(function ($channel, $channelName) use ($request) {
@@ -21,11 +20,23 @@ class FetchChannelsController extends Controller
             });
         }
 
+        $attributes = [];
+
+        if ($request->has('info')) {
+            $attributes = explode(',', trim($request->info));
+
+            if (in_array('user_count', $attributes) && !Str::startsWith($request->filter_by_prefix, 'presence-')) {
+                throw new HttpException(400, 'Request must be limited to presence channels in order to fetch user_count');
+            }
+        }
+
         return [
-            'channels' => $channels->map(function ($channel) {
-                return [
-                    'user_count' => count($channel->getUsers()),
-                ];
+            'channels' => $channels->map(function ($channel) use ($attributes) {
+                $info = new \stdClass;
+                if (in_array('user_count', $attributes)) {
+                    $info->user_count = count($channel->getUsers());
+                }
+                return $info;
             })->toArray() ?: new \stdClass,
         ];
     }

--- a/src/HttpApi/Controllers/FetchChannelsController.php
+++ b/src/HttpApi/Controllers/FetchChannelsController.php
@@ -6,7 +6,6 @@ use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Symfony\Component\HttpKernel\Exception\HttpException;
-use BeyondCode\LaravelWebSockets\WebSockets\Channels\PresenceChannel;
 
 class FetchChannelsController extends Controller
 {
@@ -25,7 +24,7 @@ class FetchChannelsController extends Controller
         if ($request->has('info')) {
             $attributes = explode(',', trim($request->info));
 
-            if (in_array('user_count', $attributes) && !Str::startsWith($request->filter_by_prefix, 'presence-')) {
+            if (in_array('user_count', $attributes) && ! Str::startsWith($request->filter_by_prefix, 'presence-')) {
                 throw new HttpException(400, 'Request must be limited to presence channels in order to fetch user_count');
             }
         }
@@ -36,6 +35,7 @@ class FetchChannelsController extends Controller
                 if (in_array('user_count', $attributes)) {
                     $info->user_count = count($channel->getUsers());
                 }
+
                 return $info;
             })->toArray() ?: new \stdClass,
         ];


### PR DESCRIPTION
Fixes #149

Currently, we can only get presence channels, because there is a filter in code:
https://github.com/beyondcode/laravel-websockets/blob/1c2b89b54d8d9d1c796b8391e41207da2a2f2423/src/HttpApi/Controllers/FetchChannelsController.php#L14-L16

But according to Pusher API documentation, there is no limitations needed, and presence channels should be filtered using `filter_by_prefix=presence-`:

https://pusher.com/docs/rest_api#method-get-channels

In this pull request, I implemented correct behavior for this endpoint:
- List with all channels now returned
- Attribute `user_count` must be requested via `info` query param
- Error code `400` will be returned if `user_count` is requested, and the request is not limited to presence channels
