### PR TITLE
Update websockets.php

### DIFF
--- a/config/websockets.php
+++ b/config/websockets.php
@@ -98,18 +98,18 @@ return [
          * certificate chain of issuers. The private key also may be contained
          * in a separate file specified by local_pk.
          */
-        'local_cert' => null,
+        'local_cert' => env('LARAVEL_WEBSOCKETS_SSL_LOCAL_CERT', null),
 
         /*
          * Path to local private key file on filesystem in case of separate files for
          * certificate (local_cert) and private key.
          */
-        'local_pk' => null,
+        'local_pk' => env('LARAVEL_WEBSOCKETS_SSL_LOCAL_PK', null),
 
         /*
          * Passphrase for your local_cert file.
          */
-        'passphrase' => null,
+        'passphrase' => env('LARAVEL_WEBSOCKETS_SSL_PASSPHRASE', null),
     ],
 
     /*


### PR DESCRIPTION
Accept SSL certificate paths through `.env` file.

This is to support projects that exist as multiple clones of the same repository.

`config/websockets.php` is generally tracked by git, making it difficult to pick the unique certificates, per installation.