### PR TITLE
Allow CustomWebSocketHandler to have access to Event Loop.

### DIFF
--- a/src/Server/WebSocketServerFactory.php
+++ b/src/Server/WebSocketServerFactory.php
@@ -83,6 +83,10 @@ class WebSocketServerFactory
 
         $router = new Router($urlMatcher);
 
+        if (method_exists($router, 'withEventLoop')) {
+            $router->withEventLoop($this->loop);
+        }
+
         $app = new OriginCheck($router, config('websockets.allowed_origins', []));
 
         $httpServer = new HttpServer($app, config('websockets.max_request_size_in_kb') * 1024);


### PR DESCRIPTION
As describe in my Twitter enquiry, I'm planning to reuse the `$loop` registered by `laravel-websockets` to be used in my custom websocket handler. 

An example usage:

```php
<?php

namespace App;

class MyCustomWebsocketHandler implements MessageComponentInterface 
{
    public function withEventLoop(LoopInterface $loop) 
    {
        // interact with $loop.
    }
}
```

Signed-off-by: Mior Muhammad Zaki <crynobone@gmail.com>