### PR TITLE
Add the ability to limit the maximum concurrent connections per appli…

### DIFF
--- a/config/websockets.php
+++ b/config/websockets.php
@@ -8,6 +8,9 @@ return [
      * This package comes with multi tenancy out of the box. Here you can
      * configure the different apps that can use the webSockets server.
      *
+     * Optionally you specify capacity so you can limit the maximum
+     * concurrent connections for a specific app.
+     *
      * Optionally you can disable client events so clients cannot send
      * messages to each other via the webSockets.
      */
@@ -17,6 +20,7 @@ return [
             'name' => env('APP_NAME'),
             'key' => env('PUSHER_APP_KEY'),
             'secret' => env('PUSHER_APP_SECRET'),
+            'capacity' => null,
             'enable_client_messages' => false,
             'enable_statistics' => true,
         ],

--- a/src/Apps/App.php
+++ b/src/Apps/App.php
@@ -21,6 +21,9 @@ class App
     /** @var string|null */
     public $host;
 
+    /** @var int|null */
+    public $capacity = null;
+
     /** @var bool */
     public $clientMessagesEnabled = false;
 
@@ -76,6 +79,13 @@ class App
     public function enableClientMessages(bool $enabled = true)
     {
         $this->clientMessagesEnabled = $enabled;
+
+        return $this;
+    }
+
+    public function setCapacity($capacity)
+    {
+        $this->capacity = $capacity;
 
         return $this;
     }

--- a/src/Apps/App.php
+++ b/src/Apps/App.php
@@ -83,7 +83,7 @@ class App
         return $this;
     }
 
-    public function setCapacity($capacity)
+    public function setCapacity(?int $capacity)
     {
         $this->capacity = $capacity;
 

--- a/src/Apps/ConfigAppProvider.php
+++ b/src/Apps/ConfigAppProvider.php
@@ -73,7 +73,8 @@ class ConfigAppProvider implements AppProvider
 
         $app
             ->enableClientMessages($appAttributes['enable_client_messages'])
-            ->enableStatistics($appAttributes['enable_statistics']);
+            ->enableStatistics($appAttributes['enable_statistics'])
+            ->setCapacity($appAttributes['capacity'] ?? null);
 
         return $app;
     }

--- a/src/WebSockets/Exceptions/ConnectionsOverCapacity.php
+++ b/src/WebSockets/Exceptions/ConnectionsOverCapacity.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace BeyondCode\LaravelWebSockets\WebSockets\Exceptions;
+
+class ConnectionsOverCapacity extends WebSocketException
+{
+    public function __construct()
+    {
+        $this->message = 'Over capacity';
+
+        // @See https://pusher.com/docs/pusher_protocol#error-codes
+        // Indicates an error resulting in the connection
+        // being closed by Pusher, and that the client may reconnect after 1s or more.
+        $this->code = 4100;
+    }
+}

--- a/src/WebSockets/WebSocketHandler.php
+++ b/src/WebSockets/WebSocketHandler.php
@@ -2,7 +2,6 @@
 
 namespace BeyondCode\LaravelWebSockets\WebSockets;
 
-use BeyondCode\LaravelWebSockets\WebSockets\Exceptions\ConnectionsOverCapacity;
 use Exception;
 use Ratchet\ConnectionInterface;
 use BeyondCode\LaravelWebSockets\Apps\App;
@@ -15,6 +14,7 @@ use BeyondCode\LaravelWebSockets\WebSockets\Channels\ChannelManager;
 use BeyondCode\LaravelWebSockets\WebSockets\Exceptions\UnknownAppKey;
 use BeyondCode\LaravelWebSockets\WebSockets\Exceptions\WebSocketException;
 use BeyondCode\LaravelWebSockets\WebSockets\Messages\PusherMessageFactory;
+use BeyondCode\LaravelWebSockets\WebSockets\Exceptions\ConnectionsOverCapacity;
 
 class WebSocketHandler implements MessageComponentInterface
 {

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -36,7 +36,6 @@ class ConnectionTest extends TestCase
         $this->getConnectedWebSocketConnection(['test-channel']);
         $this->expectException(ConnectionsOverCapacity::class);
         $this->getConnectedWebSocketConnection(['test-channel']);
-
     }
 
     /** @test */

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -5,6 +5,7 @@ namespace BeyondCode\LaravelWebSockets\Tests;
 use BeyondCode\LaravelWebSockets\Apps\App;
 use BeyondCode\LaravelWebSockets\Tests\Mocks\Message;
 use BeyondCode\LaravelWebSockets\WebSockets\Exceptions\UnknownAppKey;
+use BeyondCode\LaravelWebSockets\WebSockets\Exceptions\ConnectionsOverCapacity;
 
 class ConnectionTest extends TestCase
 {
@@ -24,6 +25,18 @@ class ConnectionTest extends TestCase
         $this->pusherServer->onOpen($connection);
 
         $connection->assertSentEvent('pusher:connection_established');
+    }
+
+    /** @test */
+    public function app_can_not_exceed_maximum_capacity()
+    {
+        $this->app['config']->set('websockets.apps.0.capacity', 2);
+
+        $this->getConnectedWebSocketConnection(['test-channel']);
+        $this->getConnectedWebSocketConnection(['test-channel']);
+        $this->expectException(ConnectionsOverCapacity::class);
+        $this->getConnectedWebSocketConnection(['test-channel']);
+
     }
 
     /** @test */

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -43,6 +43,7 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
                 'id' => 1234,
                 'key' => 'TestKey',
                 'secret' => 'TestSecret',
+                'capacity' => null,
                 'enable_client_messages' => false,
                 'enable_statistics' => true,
             ],


### PR DESCRIPTION
This pull request gives the ability to **optionally** limit the maximum concurrent connections per application.

You can specify the maximum concurrent connections via `capacity` app property in config, for example:
```php
//...
return [

    /*
     * This package comes with multi tenancy out of the box. Here you can
     * configure the different apps that can use the webSockets server.
     *
     * Optionally you can disable client events so clients cannot send
     * messages to each other via the webSockets.
     */
    'apps' => [
        [
            'id' => env('PUSHER_APP_ID'),
            'name' => env('APP_NAME'),
            'key' => env('PUSHER_APP_KEY'),
            'secret' => env('PUSHER_APP_SECRET'),
            'capacity' => 100, // or NULL for UNLIMITED concurrent connections
            'enable_client_messages' => true,
            'enable_statistics' => true,
        ],
    ],
//...
```
This is so helpful, for example if you have multiple apps for your clients you may wish to limit the maximum connections per app.