### PR TITLE
Fix/Feature : Fixing ability to add custom handlers to a route by add…

### DIFF
--- a/src/Console/StartWebSocketServer.php
+++ b/src/Console/StartWebSocketServer.php
@@ -44,6 +44,7 @@ class StartWebSocketServer extends Command
             ->configureMessageLogger()
             ->configureConnectionLogger()
             ->registerEchoRoutes()
+            ->registerCustomRoutes()
             ->startWebSocketServer();
     }
 
@@ -106,6 +107,13 @@ class StartWebSocketServer extends Command
     protected function registerEchoRoutes()
     {
         WebSocketsRouter::echo();
+
+        return $this;
+    }
+
+    protected function registerCustomRoutes()
+    {
+        WebSocketsRouter::customRoutes();
 
         return $this;
     }

--- a/src/Server/Router.php
+++ b/src/Server/Router.php
@@ -3,6 +3,7 @@
 namespace BeyondCode\LaravelWebSockets\Server;
 
 use Ratchet\WebSocket\WsServer;
+use Illuminate\Support\Collection;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 use Ratchet\WebSocket\MessageComponentInterface;
@@ -18,10 +19,12 @@ class Router
 {
     /** @var \Symfony\Component\Routing\RouteCollection */
     protected $routes;
+    protected $customRoutes;
 
     public function __construct()
     {
         $this->routes = new RouteCollection;
+        $this->customRoutes = new Collection();
     }
 
     public function getRoutes(): RouteCollection
@@ -37,6 +40,13 @@ class Router
         $this->get('/apps/{appId}/channels', FetchChannelsController::class);
         $this->get('/apps/{appId}/channels/{channelName}', FetchChannelController::class);
         $this->get('/apps/{appId}/channels/{channelName}/users', FetchUsersController::class);
+    }
+
+    public function customRoutes()
+    {
+        $this->customRoutes->each(function ($action, $uri) {
+            $this->get($uri, $action);
+        });
     }
 
     public function get(string $uri, $action)
@@ -70,7 +80,7 @@ class Router
             throw InvalidWebSocketController::withController($action);
         }
 
-        $this->get($uri, $action);
+        $this->customRoutes->put($uri, $action);
     }
 
     public function addRoute(string $method, string $uri, $action)


### PR DESCRIPTION
Fixes https://github.com/beyondcode/laravel-websockets/issues/21 
 
Fixing ability to add custom handlers to a route by adding a custom routes method to the router.

This is because the route is registered before the command is fired. The command configures the bindings for the logger, hence why you get an error.



I did not see where we could add this to the docs but this is how you would use it.

```php
<?php

namespace App\Providers;

use App\Services\AssetService;
use App\Services\GuestService;
use Illuminate\Support\ServiceProvider;
use App\WebSocketHandlers\ClientSocketHandler;
use BeyondCode\LaravelWebSockets\Facades\WebSocketsRouter;

class AppServiceProvider extends ServiceProvider
{
    /**
     * Register any application services.
     *
     * @return void
     */
    public function register()
    {
        $this->app->bind(AssetService::class, AssetService::class);
        $this->app->bind(GuestService::class, GuestService::class);

        if ($this->app->environment() !== 'production') {
            $this->app->register(\Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider::class);
        }
    }

    /**
     * Bootstrap any application services.
     *
     * @return void
     */
    public function boot()
    {
        WebSocketsRouter::webSocket('/app/{appKey}/{apiKey}', ClientSocketHandler::class);
    }
}

```