### PR TITLE
Enable logging in Dashboard Event Creator

### DIFF
--- a/src/Dashboard/Http/Controllers/SendMessage.php
+++ b/src/Dashboard/Http/Controllers/SendMessage.php
@@ -5,6 +5,7 @@ namespace BeyondCode\LaravelWebSockets\Dashboard\Http\Controllers;
 use BeyondCode\LaravelWebSockets\Statistics\Rules\AppId;
 use Illuminate\Broadcasting\Broadcasters\PusherBroadcaster;
 use Illuminate\Http\Request;
+use Psr\Log\LoggerInterface;
 use Pusher\Pusher;
 
 class SendMessage
@@ -37,6 +38,8 @@ class SendMessage
             $validated['appId'],
             config('broadcasting.connections.pusher.options', [])
         );
+
+        $pusher->setLogger(app()->make(LoggerInterface::class));
 
         return new PusherBroadcaster($pusher);
     }


### PR DESCRIPTION
As the Event Creator is mostly used for debugging I feel that logging should be enabled by default.

Closes #321 