### PR TITLE
Implement event dispatching for client messages

### DIFF
--- a/config/websockets.php
+++ b/config/websockets.php
@@ -22,6 +22,7 @@ return [
             'secret' => env('PUSHER_APP_SECRET'),
             'capacity' => null,
             'enable_client_messages' => false,
+            'dispatch_events_for_client_messages' => [],
             'enable_statistics' => true,
         ],
     ],

--- a/src/Apps/App.php
+++ b/src/Apps/App.php
@@ -27,6 +27,9 @@ class App
     /** @var bool */
     public $clientMessagesEnabled = false;
 
+    /** @var array */
+    public $dispatchEventsForClientMessages = [];
+
     /** @var bool */
     public $statisticsEnabled = true;
 
@@ -79,6 +82,13 @@ class App
     public function enableClientMessages(bool $enabled = true)
     {
         $this->clientMessagesEnabled = $enabled;
+
+        return $this;
+    }
+
+    public function dispatchEventsForClientMessages(array $events = [])
+    {
+        $this->dispatchEventsForClientMessages = $events;
 
         return $this;
     }

--- a/src/Apps/ConfigAppProvider.php
+++ b/src/Apps/ConfigAppProvider.php
@@ -71,6 +71,10 @@ class ConfigAppProvider implements AppProvider
             $app->setHost($appAttributes['host']);
         }
 
+        if (isset($appAttributes['dispatch_events_for_client_messages'])) {
+            $app->dispatchEventsForClientMessages($appAttributes['dispatch_events_for_client_messages']);
+        }
+
         $app
             ->enableClientMessages($appAttributes['enable_client_messages'])
             ->enableStatistics($appAttributes['enable_statistics'])

--- a/src/WebSockets/WebSocketHandler.php
+++ b/src/WebSockets/WebSocketHandler.php
@@ -41,6 +41,8 @@ class WebSocketHandler implements MessageComponentInterface
 
         $pusherMessage->respond();
 
+        StatisticsLogger::webSocketMessage($connection);
+
         if ($connection->app->clientMessagesEnabled) {
             $payload = json_decode($message->getPayload());
             if (isset($payload->event)
@@ -122,6 +124,6 @@ class WebSocketHandler implements MessageComponentInterface
 
     protected function dispatchClientMessageEvent(string $event, $payload)
     {
-        app('events')->dispatch('websockets.' . $event, [$payload]);
+        app('events')->dispatch('websockets.'.$event, [$payload]);
     }
 }

--- a/tests/Messages/PusherClientMessageTest.php
+++ b/tests/Messages/PusherClientMessageTest.php
@@ -2,6 +2,7 @@
 
 namespace BeyondCode\LaravelWebSockets\Tests\Messages;
 
+use Illuminate\Support\Facades\Event;
 use BeyondCode\LaravelWebSockets\Tests\TestCase;
 use BeyondCode\LaravelWebSockets\Tests\Mocks\Message;
 
@@ -59,5 +60,78 @@ class PusherClientMessageTest extends TestCase
                 'client-event' => 'test',
             ],
         ]);
+    }
+
+    /** @test */
+    public function client_messages_dispatch_only_specified_wildcard_events_when_enabled()
+    {
+        Event::fake();
+
+        $this->app['config']->set('websockets.apps', [
+            [
+                'name' => 'Test App',
+                'id' => 1234,
+                'key' => 'TestKey',
+                'secret' => 'TestSecret',
+                'enable_client_messages' => true,
+                'dispatch_events_for_client_messages' => ['client-test'],
+                'enable_statistics' => true,
+            ],
+        ]);
+
+        $connection = $this->getConnectedWebSocketConnection(['test-channel']);
+
+        $message1 = new Message(json_encode([
+            'event' => 'client-test',
+            'channel' => 'test-channel',
+            'data' => [
+                'client-event' => 'test',
+            ],
+        ]));
+        $message2 = new Message(json_encode([
+            'event' => 'client-test2',
+            'channel' => 'test-channel',
+            'data' => [
+                'client-event' => 'other test',
+            ],
+        ]));
+
+        $this->pusherServer->onMessage($connection, $message1);
+        $this->pusherServer->onMessage($connection, $message2);
+
+        Event::assertDispatched('websockets.client-test');
+        Event::assertNotDispatched('websockets.client-test2');
+    }
+
+    /** @test */
+    public function client_messages_do_not_dispatch_wildcard_events_when_client_messages_are_disabled()
+    {
+        Event::fake();
+
+        $this->app['config']->set('websockets.apps', [
+            [
+                'name' => 'Test App',
+                'id' => 1234,
+                'key' => 'TestKey',
+                'secret' => 'TestSecret',
+                'enable_client_messages' => false,
+                'dispatch_events_for_client_messages' => ['client-test'],
+                'enable_statistics' => true,
+            ],
+        ]);
+
+        $connection = $this->getConnectedWebSocketConnection(['test-channel']);
+
+        $message = new Message(json_encode([
+            'event' => 'client-test',
+            'channel' => 'test-channel',
+            'data' => [
+                'client-event' => 'test',
+            ],
+        ]));
+
+        $this->pusherServer->onMessage($connection, $message);
+
+        Event::assertNotDispatched('websockets.client-test');
     }
 }


### PR DESCRIPTION
Greetings!

This is something I've done in one of my projects using `Laravel Websockets` when the need arrived to trigger certain actions for when specific client messages were received by websocket server.

This is a non-breaking change that will make Laravel Websockets propagate certain events from client messages (when enabled) to Laravel's events circuit.

For example, with this change we can configure our app in `config/websockets.php` like this:
```php
...
'apps' => [
    [
        'id' => env('PUSHER_APP_ID'),
        'name' => env('APP_NAME'),
        'key' => env('PUSHER_APP_KEY'),
        'secret' => env('PUSHER_APP_SECRET'),
        'capacity' => null,
        'enable_client_messages' => true,

        // Here we can configure which events from client messages will be dispatched:
        'dispatch_events_for_client_messages' => ['client-message-read'],

        'enable_statistics' => true,
    ],
],
...
```
This will allow us to listen for `websockets.client-message-read` event (it will receive entire message payload as it's only parameter):
```php
Event::listen('websockets.client-message-read', function ($payload) {
    // Here goes our backend stuff, for example, reading message IDs from
    // $payload->data and updating them as read in DB.
    // ...
});
```