### PR TITLE
Debug dashboard connection exceeded error added

### DIFF
--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -142,6 +142,15 @@
                     this.logs = [];
                 });
 
+                this.pusher.connection.bind('error', event => {
+                    if (event.error.data.code === 4100) {
+                        $('div#status').text("Maximum connection limit exceeded!");
+                        this.connected = false;
+                        this.logs = [];
+                        throw new Error("Over capacity");
+                    }
+                });
+
                 this.subscribeToAllChannels();
 
                 this.subscribeToStatistics();


### PR DESCRIPTION
Debug dashboard will now show error message for maximum connection limit exceeded for a single app instead of showing nothing.