### PR TITLE
Allow the use of pusher-php-server 4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "illuminate/http": "5.7.* || 5.8.*",
         "illuminate/routing": "5.7.* || 5.8.*",
         "illuminate/support": "5.7.* || 5.8.*",
-        "pusher/pusher-php-server": "~3.0",
+        "pusher/pusher-php-server": "~3.0 || ~4.0",
         "symfony/http-kernel": "~4.0",
         "symfony/psr-http-message-bridge": "^1.1"
     },


### PR DESCRIPTION
Running the test suite locally did not show any problems (all 44 tests have passed).


```sh
PHPUnit 7.5.13 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.3.3
Configuration: /Users/tomdewit/Packages/laravel-websockets/phpunit.xml.dist
Error:         No code coverage driver is available

............................................                      44 / 44 (100%)

Time: 772 ms, Memory: 22.00 MB

OK (44 tests, 96 assertions)
```