### PR TITLE
update react dns to v1.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
         "illuminate/support": "5.7.* || 5.8.*",
         "pusher/pusher-php-server": "~3.0 || ~4.0",
         "symfony/http-kernel": "~4.0",
-        "symfony/psr-http-message-bridge": "^1.1"
+        "symfony/psr-http-message-bridge": "^1.1",
+        "react/dns": "^1.1"
     },
     "require-dev": {
         "mockery/mockery": "^1.2",


### PR DESCRIPTION
The resolverinterface (used in #223)  was newly introduced in reach/dns 1.1. This PR to avoid that people who are on react/dns 1.0 get issues.