### PR TITLE
[feature] Add restart command for WebSocket server

### DIFF
--- a/src/Console/RestartWebSocketServer.php
+++ b/src/Console/RestartWebSocketServer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace BeyondCode\LaravelWebSockets\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\InteractsWithTime;
+
+class RestartWebSocketServer extends Command
+{
+    use InteractsWithTime;
+
+    protected $signature = 'websockets:restart';
+
+    protected $description = 'Restart the Laravel WebSocket Server';
+
+    public function handle()
+    {
+        Cache::forever('beyondcode:websockets:restart', $this->currentTime());
+
+        $this->info('Broadcasting WebSocket server restart signal.');
+    }
+}

--- a/src/WebSocketsServiceProvider.php
+++ b/src/WebSocketsServiceProvider.php
@@ -41,6 +41,7 @@ class WebSocketsServiceProvider extends ServiceProvider
         $this->commands([
             Console\StartWebSocketServer::class,
             Console\CleanStatistics::class,
+            Console\RestartWebSocketServer::class,
         ]);
     }
 

--- a/tests/Commands/RestartWebSocketServerTest.php
+++ b/tests/Commands/RestartWebSocketServerTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace BeyondCode\LaravelWebSockets\Tests\Commands;
+
+use Artisan;
+use BeyondCode\LaravelWebSockets\Tests\TestCase;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\InteractsWithTime;
+
+class RestartWebSocketServerTest extends TestCase
+{
+    use InteractsWithTime;
+
+    /** @test */
+    public function it_can_broadcast_restart_signal()
+    {
+        $start = $this->currentTime();
+
+        Artisan::call('websockets:restart');
+
+        $this->assertGreaterThanOrEqual($start, Cache::get('beyondcode:websockets:restart', 0));
+    }
+}


### PR DESCRIPTION
This PR adds a console command for restart the WebSocket server.

For example if you deploy with Laravel Envoyer the server should be restarted because of a new version of the WebSocket package.

The command is inspired by the queue restart command.

Please note that this only works if the server is automatically restarted by Supervisor or something else as the server is only stopped with this command.