### PR TITLE
added support for pusher-php-server 4.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "illuminate/http": "5.7.* || 5.8.* || ^6.0",
         "illuminate/routing": "5.7.* || 5.8.* || ^6.0",
         "illuminate/support": "5.7.* || 5.8.* || ^6.0",
-        "pusher/pusher-php-server": "~3.0 || ~4.0",
+        "pusher/pusher-php-server": "~3.0 || ~4.0 || ~4.1",
         "react/dns": "^1.1",
         "symfony/http-kernel": "~4.0",
         "symfony/psr-http-message-bridge": "^1.1"


### PR DESCRIPTION
pusher-php-server 4.1 Added Support for PHP 7.4
In order to eliminate support for php 7.4 installation error