### PR TITLE
Bump deps for Laravel 7 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "illuminate/support": "5.7.* || 5.8.* || ^6.0 || ^7.0",
         "pusher/pusher-php-server": "~3.0 || ~4.0",
         "react/dns": "^1.1",
-        "symfony/http-kernel": "~5.0",
+        "symfony/http-kernel": "~4.0 || ~5.0",
         "symfony/psr-http-message-bridge": "^1.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -28,19 +28,19 @@
         "clue/buzz-react": "^2.5",
         "facade/ignition-contracts": "^1.0",
         "guzzlehttp/psr7": "^1.5",
-        "illuminate/broadcasting": "5.7.* || 5.8.* || ^6.0",
-        "illuminate/console": "5.7.* || 5.8.* || ^6.0",
-        "illuminate/http": "5.7.* || 5.8.* || ^6.0",
-        "illuminate/routing": "5.7.* || 5.8.* || ^6.0",
-        "illuminate/support": "5.7.* || 5.8.* || ^6.0",
+        "illuminate/broadcasting": "5.7.* || 5.8.* || ^6.0 || ^7.0",
+        "illuminate/console": "5.7.* || 5.8.* || ^6.0 || ^7.0",
+        "illuminate/http": "5.7.* || 5.8.* || ^6.0 || ^7.0",
+        "illuminate/routing": "5.7.* || 5.8.* || ^6.0 || ^7.0",
+        "illuminate/support": "5.7.* || 5.8.* || ^6.0 || ^7.0",
         "pusher/pusher-php-server": "~3.0 || ~4.0",
         "react/dns": "^1.1",
-        "symfony/http-kernel": "~4.0",
+        "symfony/http-kernel": "~5.0",
         "symfony/psr-http-message-bridge": "^1.1"
     },
     "require-dev": {
         "mockery/mockery": "^1.2",
-        "orchestra/testbench": "3.7.* || 3.8.* || ^4.0",
+        "orchestra/testbench": "3.7.* || 3.8.* || ^4.0 || ^5.0",
         "phpunit/phpunit": "^7.0 || ^8.0"
     },
     "autoload": {


### PR DESCRIPTION
Fixes #327 

* Bumps `illuminate/*` packages to support `^7.0`
* Bumps `symfony/http-kernel` to `~5.0` to be on par with Laravel 7
* Bumps `orchestra/testbench` to `^5.0` to support Laravel 7

Running `phpunit` only throws a deprecation warning about `assertArraySubset() is deprecated and will be removed in PHPUnit 9`, which I think can best be dealt with in a separate issue.

Other than that, no errors.

The only thing I wonder is the direct bump of `symfony/http-kernel` to `~5.0`, whether or not this causes issues with older Laravel installations, and if it would be better to do `"^4.0 || ^5.0"`