### PR TITLE
Fix broken link in FAQ

### DIFF
--- a/docs/faq/scaling.md
+++ b/docs/faq/scaling.md
@@ -15,4 +15,4 @@ Here is another benchmark that was run on a 2GB Digital Ocean droplet with 2 CPU
 
 ![Benchmark](/img/simultaneous_users_2gb.png)
 
-Make sure to take a look at the [Deployment Tips](/1.0/faq/deploying.html) to find out how to improve your specific setup.
+Make sure to take a look at the [Deployment Tips](/docs/laravel-websockets/faq/deploying) to find out how to improve your specific setup.


### PR DESCRIPTION
Just a fix for a broken link that I encountered while perusing the documentation on [beyondco.de](https://beyondco.de).