### PR TITLE
[draft] Update the User info in the Presence Channel call

### DIFF
--- a/src/HttpApi/Controllers/UpdateUserInfoController.php
+++ b/src/HttpApi/Controllers/UpdateUserInfoController.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace BeyondCode\LaravelWebSockets\HttpApi\Controllers;
+
+use BeyondCode\LaravelWebSockets\WebSockets\Channels\PresenceChannel;
+use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class UpdateUserInfoController extends Controller
+{
+    public function __invoke(Request $request)
+    {
+        $channel = $this->channelManager->find($request->appId, $request->channelName);
+
+        if (is_null($channel)) {
+            throw new HttpException(404, 'Unknown channel "'.$request->channelName.'"');
+        }
+
+        if (! $channel instanceof PresenceChannel) {
+            throw new HttpException(400, 'Invalid presence channel "'.$request->channelName.'"');
+        }
+
+        $user = Collection::make($channel->getUsers())->filter(function($user) use ($request) {
+            return $user->user_id === (int) $request->userId;
+        })->first();
+
+        if (is_null($user)) {
+            throw new HttpException(404, 'Unknown user "'.$request->userId.'"');
+        }
+
+        $channel->updateUserInfo($user->user_id, (object) $request->info);
+    }
+}

--- a/src/Server/Router.php
+++ b/src/Server/Router.php
@@ -7,6 +7,7 @@ use BeyondCode\LaravelWebSockets\HttpApi\Controllers\FetchChannelController;
 use BeyondCode\LaravelWebSockets\HttpApi\Controllers\FetchChannelsController;
 use BeyondCode\LaravelWebSockets\HttpApi\Controllers\FetchUsersController;
 use BeyondCode\LaravelWebSockets\HttpApi\Controllers\TriggerEventController;
+use BeyondCode\LaravelWebSockets\HttpApi\Controllers\UpdateUserInfoController;
 use BeyondCode\LaravelWebSockets\Server\Logger\WebsocketsLogger;
 use BeyondCode\LaravelWebSockets\WebSockets\WebSocketHandler;
 use Illuminate\Support\Collection;
@@ -40,6 +41,7 @@ class Router
         $this->get('/apps/{appId}/channels', FetchChannelsController::class);
         $this->get('/apps/{appId}/channels/{channelName}', FetchChannelController::class);
         $this->get('/apps/{appId}/channels/{channelName}/users', FetchUsersController::class);
+        $this->put('/apps/{appId}/channels/{channelName}/users/{userId}', UpdateUserInfoController::class);
     }
 
     public function customRoutes()

--- a/src/WebSockets/Channels/PresenceChannel.php
+++ b/src/WebSockets/Channels/PresenceChannel.php
@@ -14,6 +14,16 @@ class PresenceChannel extends Channel
         return $this->users;
     }
 
+    public function updateUserInfo(int $id, object $info)
+    {
+        foreach ($this->users as $key => $user) {
+            if ($user->user_id === $id) {
+                $user->user_info = $info;
+                break;
+            }
+        }
+    }
+
     /*
      * @link https://pusher.com/docs/pusher_protocol#presence-channel-events
      */

--- a/tests/HttpApi/UpdateUserInfoTest.php
+++ b/tests/HttpApi/UpdateUserInfoTest.php
@@ -67,31 +67,6 @@ class UpdateUserInfoTest extends TestCase
     }
 
     /** @test */
-    public function it_only_returns_works_for_presence_channels()
-    {
-        $this->expectException(HttpException::class);
-        $this->expectExceptionMessage('Invalid presence channel');
-
-        $this->getConnectedWebSocketConnection(['my-channel']);
-
-        $connection = new Connection();
-
-        $requestPath = '/apps/1234/channels/my-channel/users';
-        $routeParams = [
-            'appId' => '1234',
-            'channelName' => 'my-channel',
-        ];
-
-        $queryString = Pusher::build_auth_query_string('TestKey', 'TestSecret', 'PUT', $requestPath);
-
-        $request = new Request('PUT', "{$requestPath}?{$queryString}&".http_build_query($routeParams));
-
-        $controller = app(UpdateUserInfoController::class);
-
-        $controller->onOpen($connection, $request);
-    }
-
-    /** @test */
     public function it_returns_404_for_invalid_channels()
     {
         $this->expectException(HttpException::class);

--- a/tests/HttpApi/UpdateUserInfoTest.php
+++ b/tests/HttpApi/UpdateUserInfoTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace BeyondCode\LaravelWebSockets\Tests\HttpApi;
+
+use BeyondCode\LaravelWebSockets\HttpApi\Controllers\UpdateUserInfoController;
+use BeyondCode\LaravelWebSockets\Tests\Mocks\Connection;
+use BeyondCode\LaravelWebSockets\Tests\TestCase;
+use GuzzleHttp\Psr7\Request;
+use Illuminate\Http\JsonResponse;
+use Pusher\Pusher;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class UpdateUserInfoTest extends TestCase
+{
+    /** @test */
+    public function invalid_signatures_can_not_access_the_api()
+    {
+        $this->expectException(HttpException::class);
+        $this->expectExceptionMessage('Invalid auth signature provided.');
+
+        $connection = new Connection();
+
+        $requestPath = '/apps/1234/channels/my-channel/users';
+        $routeParams = [
+            'appId' => '1234',
+            'channelName' => 'my-channel',
+        ];
+
+        $queryString = Pusher::build_auth_query_string('TestKey', 'InvalidSecret', 'PUT', $requestPath);
+
+        $request = new Request('PUT', "{$requestPath}?{$queryString}&".http_build_query($routeParams));
+
+        $controller = app(UpdateUserInfoController::class);
+
+        $controller->onOpen($connection, $request);
+    }
+
+    /** @test */
+    public function it_returns_the_channel_information()
+    {
+        $this->getConnectedWebSocketConnection(['my-channel']);
+        $this->getConnectedWebSocketConnection(['my-channel']);
+
+        $connection = new Connection();
+
+        $requestPath = '/apps/1234/channel/my-channel';
+        $routeParams = [
+            'appId' => '1234',
+            'channelName' => 'my-channel',
+        ];
+
+        $queryString = Pusher::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath);
+
+        $request = new Request('GET', "{$requestPath}?{$queryString}&".http_build_query($routeParams));
+
+        $controller = app(FetchChannelController::class);
+
+        $controller->onOpen($connection, $request);
+
+        /** @var JsonResponse $response */
+        $response = array_pop($connection->sentRawData);
+
+        $this->assertSame([
+            'occupied' => true,
+            'subscription_count' => 2,
+        ], json_decode($response->getContent(), true));
+    }
+
+    /** @test */
+    public function it_only_returns_works_for_presence_channels()
+    {
+        $this->expectException(HttpException::class);
+        $this->expectExceptionMessage('Invalid presence channel');
+
+        $this->getConnectedWebSocketConnection(['my-channel']);
+
+        $connection = new Connection();
+
+        $requestPath = '/apps/1234/channels/my-channel/users';
+        $routeParams = [
+            'appId' => '1234',
+            'channelName' => 'my-channel',
+        ];
+
+        $queryString = Pusher::build_auth_query_string('TestKey', 'TestSecret', 'PUT', $requestPath);
+
+        $request = new Request('PUT', "{$requestPath}?{$queryString}&".http_build_query($routeParams));
+
+        $controller = app(UpdateUserInfoController::class);
+
+        $controller->onOpen($connection, $request);
+    }
+
+    /** @test */
+    public function it_returns_404_for_invalid_channels()
+    {
+        $this->expectException(HttpException::class);
+        $this->expectExceptionMessage('Unknown channel');
+
+        $this->getConnectedWebSocketConnection(['my-channel']);
+
+        $connection = new Connection();
+
+        $requestPath = '/apps/1234/channels/invalid-channel/users';
+        $routeParams = [
+            'appId' => '1234',
+            'channelName' => 'invalid-channel',
+        ];
+
+        $queryString = Pusher::build_auth_query_string('TestKey', 'TestSecret', 'PUT', $requestPath);
+
+        $request = new Request('PUT', "{$requestPath}?{$queryString}&".http_build_query($routeParams));
+
+        $controller = app(UpdateUserInfoController::class);
+
+        $controller->onOpen($connection, $request);
+
+        /** @var JsonResponse $response */
+        $response = array_pop($connection->sentRawData);
+
+        $this->assertSame([
+            'occupied' => true,
+            'subscription_count' => 2,
+        ], json_decode($response->getContent(), true));
+    }
+}

--- a/tests/HttpApi/UpdateUserInfoTest.php
+++ b/tests/HttpApi/UpdateUserInfoTest.php
@@ -36,37 +36,6 @@ class UpdateUserInfoTest extends TestCase
     }
 
     /** @test */
-    public function it_returns_the_channel_information()
-    {
-        $this->getConnectedWebSocketConnection(['my-channel']);
-        $this->getConnectedWebSocketConnection(['my-channel']);
-
-        $connection = new Connection();
-
-        $requestPath = '/apps/1234/channel/my-channel';
-        $routeParams = [
-            'appId' => '1234',
-            'channelName' => 'my-channel',
-        ];
-
-        $queryString = Pusher::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath);
-
-        $request = new Request('GET', "{$requestPath}?{$queryString}&".http_build_query($routeParams));
-
-        $controller = app(FetchChannelController::class);
-
-        $controller->onOpen($connection, $request);
-
-        /** @var JsonResponse $response */
-        $response = array_pop($connection->sentRawData);
-
-        $this->assertSame([
-            'occupied' => true,
-            'subscription_count' => 2,
-        ], json_decode($response->getContent(), true));
-    }
-
-    /** @test */
     public function it_returns_404_for_invalid_channels()
     {
         $this->expectException(HttpException::class);


### PR DESCRIPTION
This PR is not fully complete yet because it lacks the essentials tests. I'm having a little bit trouble of how I should test this feature but wanted to create the PR first to see that it will be accepted before I spend too much time on it.

Basically what I've done here is to create an API route to update the current `user_info` in presence channels. This is a highly sought after feature in Pusher but they haven't implemented it yet. You can see it here: https://stackoverflow.com/questions/24874279/how-to-change-member-info-in-pusher and https://stackoverflow.com/questions/29207414/save-to-user-info-on-pusher-presence-channels. 

Personally I need this because I'm storing data here that I need to keep in sync. The problem I have is if UserA logs in and sets his user_info to `on_call => false` and then when UserB logs in he will get the `on_call => false` data for UserA. If now UserA answers a call I send out a client event setting this data (on client side) to `on_call => true` for UserA. This all works good but if UserB now reloads his page he will get the initial user_info that was set when UserA authenticated which would be `on_call => false`.

By having an API to update the user_info state this solves my problem. When UserA accepts a call I update the state on my websocket server meaning that UserB (and every other User's joining) will now have an updated info on UserA where `on_call => true`.

Hope you would accept this Pull Request and if you do, maybe give me some pointer of how to write a good test for this functionality. Maybe I need unit test to see that the `updateUserInfo` function works properly or do it by a Controller test like I've started.