### PR TITLE
Fix multiple routes not working when Logger enabled #412

### DIFF
--- a/src/Server/Logger/WebsocketsLogger.php
+++ b/src/Server/Logger/WebsocketsLogger.php
@@ -14,7 +14,7 @@ class WebsocketsLogger extends Logger implements MessageComponentInterface
     protected $app;
 
     /**
-     * WebsocketsLogger polymorphic constructor for Logger Singleton instanciation and WSServer instanciation 
+     * WebsocketsLogger polymorphic constructor for Logger Singleton instanciation and WSServer instanciation.
      *
      * @param MessageComponentInterface|OutputInterface $app
      */
@@ -26,7 +26,7 @@ class WebsocketsLogger extends Logger implements MessageComponentInterface
             $this->app = $app;
         }
     }
-    
+
     public static function decorate(MessageComponentInterface $app): self
     {
         $logger = app(self::class);

--- a/src/Server/Logger/WebsocketsLogger.php
+++ b/src/Server/Logger/WebsocketsLogger.php
@@ -13,6 +13,20 @@ class WebsocketsLogger extends Logger implements MessageComponentInterface
     /** @var \Ratchet\Http\HttpServerInterface */
     protected $app;
 
+    /**
+     * WebsocketsLogger polymorphic constructor for Logger Singleton instanciation and WSServer instanciation 
+     *
+     * @param MessageComponentInterface|OutputInterface $app
+     */
+    public function __construct($app)
+    {
+        if ($app instanceof OutputInterface) {
+            parent::__construct($app);
+        } else {
+            $this->app = $app;
+        }
+    }
+    
     public static function decorate(MessageComponentInterface $app): self
     {
         $logger = app(self::class);


### PR DESCRIPTION
When multiple routes are declared and WebSocket logger is enabled, all the routes will use the controller of the last route declared

This fixes the issue