### PR TITLE
Fix multiple routes not working when Logger enabled beyondcode#412

### DIFF
--- a/src/Server/Logger/WebsocketsLogger.php
+++ b/src/Server/Logger/WebsocketsLogger.php
@@ -15,7 +15,7 @@ class WebsocketsLogger extends Logger implements MessageComponentInterface
 
     public static function decorate(MessageComponentInterface $app): self
     {
-        $logger = app(self::class);
+        $logger = clone app(self::class);
 
         return $logger->setApp($app);
     }


### PR DESCRIPTION
When multiple routes are declared and WebSocket logger is enabled, all the routes will use the controller of the last route declared

This fixes the issue