### PR TITLE
Required changes after pusher-js v6

### DIFF
--- a/docs/basic-usage/pusher.md
+++ b/docs/basic-usage/pusher.md
@@ -111,6 +111,7 @@ window.Echo = new Echo({
     key: 'your-pusher-key',
     wsHost: window.location.hostname,
     wsPort: 6001,
+    forceTLS: false,
     disableStats: true,
 });
 ```

--- a/docs/basic-usage/ssl.md
+++ b/docs/basic-usage/ssl.md
@@ -49,7 +49,7 @@ php artisan websockets:serve
 ## Client configuration
 
 When your SSL settings are in place and working, you still need to tell Laravel Echo that it should make use of it.
-You can do this by specifying the `encrypted` property in your JavaScript file, like this:
+You can do this by specifying the `forceTLS` property in your JavaScript file, like this:
 
 ```js
 import Echo from "laravel-echo"
@@ -62,7 +62,7 @@ window.Echo = new Echo({
     wsHost: window.location.hostname,
     wsPort: 6001,
     disableStats: true,
-    encrypted: true
+    forceTLS: true
 });
 ```
 


### PR DESCRIPTION
After pusher-js v6 the `encrypted` attribute was removed in favor of `forceTLS` and it is true by default, so we need to use `forceTLS: false`, to keep it working in local or when TLS is not enabled yet.

It is normally evidenced as a CORS issue when connecting to Laravel WebSockets.