### PR TITLE
Schema check breaks

### DIFF
--- a/src/WebSocketsServiceProvider.php
+++ b/src/WebSocketsServiceProvider.php
@@ -30,8 +30,8 @@ class WebSocketsServiceProvider extends ServiceProvider
         try {
             if (! Schema::hasTable('websockets_statistics_entries')) {
                 $this->publishes([
-                __DIR__.'/../database/migrations/create_websockets_statistics_entries_table.php.stub' => database_path('migrations/'.date('Y_m_d_His', time()).'_create_websockets_statistics_entries_table.php'),
-            ], 'migrations');
+                    __DIR__.'/../database/migrations/create_websockets_statistics_entries_table.php.stub' => database_path('migrations/'.date('Y_m_d_His', time()).'_create_websockets_statistics_entries_table.php'),
+                ], 'migrations');
             }
 
             $this

--- a/src/WebSocketsServiceProvider.php
+++ b/src/WebSocketsServiceProvider.php
@@ -26,12 +26,12 @@ class WebSocketsServiceProvider extends ServiceProvider
         ], 'config');
 
         $this->publishes([
-            __DIR__.'/../database/migrations/create_websockets_statistics_entries_table.php.stub' => database_path('migrations/'.'000000_create_websockets_statistics_entries_table.php'),
+            __DIR__.'/../database/migrations/create_websockets_statistics_entries_table.php.stub' => database_path('migrations/0000_00_00_000000_create_websockets_statistics_entries_table.php'),
         ], 'migrations');
 
         $this
-        ->registerRoutes()
-        ->registerDashboardGate();
+            ->registerRoutes()
+            ->registerDashboardGate();
 
         $this->loadViewsFrom(__DIR__.'/../resources/views/', 'websockets');
 

--- a/src/WebSocketsServiceProvider.php
+++ b/src/WebSocketsServiceProvider.php
@@ -24,21 +24,21 @@ class WebSocketsServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->publishes([
-            __DIR__ . '/../config/websockets.php' => base_path('config/websockets.php'),
+            __DIR__.'/../config/websockets.php' => base_path('config/websockets.php'),
         ], 'config');
 
         try {
-            if (!Schema::hasTable('websockets_statistics_entries')) {
+            if (! Schema::hasTable('websockets_statistics_entries')) {
                 $this->publishes([
-                    __DIR__ . '/../database/migrations/create_websockets_statistics_entries_table.php.stub' => database_path('migrations/' . date('Y_m_d_His', time()) . '_create_websockets_statistics_entries_table.php'),
-                ], 'migrations');
+                __DIR__.'/../database/migrations/create_websockets_statistics_entries_table.php.stub' => database_path('migrations/'.date('Y_m_d_His', time()).'_create_websockets_statistics_entries_table.php'),
+            ], 'migrations');
             }
 
             $this
-                ->registerRoutes()
-                ->registerDashboardGate();
+            ->registerRoutes()
+            ->registerDashboardGate();
 
-            $this->loadViewsFrom(__DIR__ . '/../resources/views/', 'websockets');
+            $this->loadViewsFrom(__DIR__.'/../resources/views/', 'websockets');
 
             $this->commands([
                 Console\StartWebSocketServer::class,
@@ -55,7 +55,7 @@ class WebSocketsServiceProvider extends ServiceProvider
 
     public function register()
     {
-        $this->mergeConfigFrom(__DIR__ . '/../config/websockets.php', 'websockets');
+        $this->mergeConfigFrom(__DIR__.'/../config/websockets.php', 'websockets');
 
         $this->app->singleton('websockets.router', function () {
             return new Router();
@@ -63,7 +63,7 @@ class WebSocketsServiceProvider extends ServiceProvider
 
         $this->app->singleton(ChannelManager::class, function () {
             return config('websockets.channel_manager') !== null && class_exists(config('websockets.channel_manager'))
-            ? app(config('websockets.channel_manager')) : new ArrayChannelManager();
+                ? app(config('websockets.channel_manager')) : new ArrayChannelManager();
         });
 
         $this->app->singleton(AppProvider::class, function () {
@@ -71,15 +71,12 @@ class WebSocketsServiceProvider extends ServiceProvider
         });
     }
 
-    /**
-     * @return mixed
-     */
     protected function registerRoutes()
     {
         Route::prefix(config('websockets.path'))->group(function () {
             Route::middleware(config('websockets.middleware', [AuthorizeDashboard::class]))->group(function () {
                 Route::get('/', ShowDashboard::class);
-                Route::get('/api/{appId}/statistics', [DashboardApiController::class, 'getStatistics']);
+                Route::get('/api/{appId}/statistics', [DashboardApiController::class,  'getStatistics']);
                 Route::post('auth', AuthenticateDashboard::class);
                 Route::post('event', SendMessage::class);
             });
@@ -92,9 +89,6 @@ class WebSocketsServiceProvider extends ServiceProvider
         return $this;
     }
 
-    /**
-     * @return mixed
-     */
     protected function registerDashboardGate()
     {
         Gate::define('viewWebSocketsDashboard', function ($user = null) {

--- a/src/WebSocketsServiceProvider.php
+++ b/src/WebSocketsServiceProvider.php
@@ -13,10 +13,8 @@ use BeyondCode\LaravelWebSockets\Statistics\Http\Controllers\WebSocketStatistics
 use BeyondCode\LaravelWebSockets\Statistics\Http\Middleware\Authorize as AuthorizeStatistics;
 use BeyondCode\LaravelWebSockets\WebSockets\Channels\ChannelManager;
 use BeyondCode\LaravelWebSockets\WebSockets\Channels\ChannelManagers\ArrayChannelManager;
-use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Route;
-use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
 
 class WebSocketsServiceProvider extends ServiceProvider
@@ -27,30 +25,21 @@ class WebSocketsServiceProvider extends ServiceProvider
             __DIR__.'/../config/websockets.php' => base_path('config/websockets.php'),
         ], 'config');
 
-        try {
-            if (! Schema::hasTable('websockets_statistics_entries')) {
-                $this->publishes([
-                    __DIR__.'/../database/migrations/create_websockets_statistics_entries_table.php.stub' => database_path('migrations/'.date('Y_m_d_His', time()).'_create_websockets_statistics_entries_table.php'),
-                ], 'migrations');
-            }
+        $this->publishes([
+            __DIR__.'/../database/migrations/create_websockets_statistics_entries_table.php.stub' => database_path('migrations/'.'000000_create_websockets_statistics_entries_table.php'),
+        ], 'migrations');
 
-            $this
-            ->registerRoutes()
-            ->registerDashboardGate();
+        $this
+        ->registerRoutes()
+        ->registerDashboardGate();
 
-            $this->loadViewsFrom(__DIR__.'/../resources/views/', 'websockets');
+        $this->loadViewsFrom(__DIR__.'/../resources/views/', 'websockets');
 
-            $this->commands([
-                Console\StartWebSocketServer::class,
-                Console\CleanStatistics::class,
-                Console\RestartWebSocketServer::class,
-            ]);
-        } catch (QueryException $e) {
-            // Exception raised by composer update
-            // Usually happens when doing on CI where no DB exists at start
-            // Either way if DB connection not obtained
-            // Catching and doing nothing is ignore for composer update
-        }
+        $this->commands([
+            Console\StartWebSocketServer::class,
+            Console\CleanStatistics::class,
+            Console\RestartWebSocketServer::class,
+        ]);
     }
 
     public function register()


### PR DESCRIPTION
## Changes

Added exception handling for QueryException which is raised when no DB is present and Schema check is called due to which exception is seen when attempting composer update when no DB connection is available, often for CI with no DB at start it breaks.