### PR TITLE
[2.x] Refactoring dashboard

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,5 +11,8 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
+[*.blade.php]
+indent_size = 2
+
 [*.md]
 trim_trailing_whitespace = false

--- a/config/websockets.php
+++ b/config/websockets.php
@@ -191,9 +191,13 @@ return [
         | store them into an array and then store them into the database
         | on each interval.
         |
+        | You can opt-in to avoid any statistics storage by setting the logger
+        | to the built-in NullLogger.
+        |
         */
 
-        'logger' => BeyondCode\LaravelWebSockets\Statistics\Logger\HttpStatisticsLogger::class,
+        'logger' => \BeyondCode\LaravelWebSockets\Statistics\Logger\HttpStatisticsLogger::class,
+        // 'logger' => \BeyondCode\LaravelWebSockets\Statistics\Logger\NullStatisticsLogger::class,
 
         /*
         |--------------------------------------------------------------------------

--- a/src/Dashboard/DashboardLogger.php
+++ b/src/Dashboard/DashboardLogger.php
@@ -10,9 +10,9 @@ class DashboardLogger
 {
     const LOG_CHANNEL_PREFIX = 'private-websockets-dashboard-';
 
-    const TYPE_DISCONNECTION = 'disconnection';
+    const TYPE_DISCONNECTED = 'disconnected';
 
-    const TYPE_CONNECTION = 'connection';
+    const TYPE_CONNECTED = 'connected';
 
     const TYPE_VACATED = 'vacated';
 
@@ -20,7 +20,7 @@ class DashboardLogger
 
     const TYPE_SUBSCRIBED = 'subscribed';
 
-    const TYPE_CLIENT_MESSAGE = 'client-message';
+    const TYPE_WS_MESSAGE = 'ws-message';
 
     const TYPE_API_MESSAGE = 'api-message';
 
@@ -28,101 +28,36 @@ class DashboardLogger
 
     const TYPE_REPLICATOR_UNSUBSCRIBED = 'replicator-unsubscribed';
 
-    public static function connection(ConnectionInterface $connection)
-    {
-        /** @var \GuzzleHttp\Psr7\Request $request */
-        $request = $connection->httpRequest;
+    const TYPE_REPLICATOR_JOINED_CHANNEL = 'replicator-joined';
 
-        static::log($connection->app->id, static::TYPE_CONNECTION, [
-            'details' => [
-                'origin' => "{$request->getUri()->getScheme()}://{$request->getUri()->getHost()}",
-                'socketId' => $connection->socketId,
-            ],
-        ]);
-    }
+    const TYPE_REPLICATOR_LEFT_CHANNEL = 'replicator-left';
 
-    public static function occupied(ConnectionInterface $connection, string $channelName)
-    {
-        static::log($connection->app->id, static::TYPE_OCCUPIED, [
-            'details' => [
-                'channel' => $channelName,
-            ],
-        ]);
-    }
+    const TYPE_REPLICATOR_MESSAGE_PUBLISHED = 'replicator-message-published';
 
-    public static function subscribed(ConnectionInterface $connection, string $channelName)
-    {
-        static::log($connection->app->id, static::TYPE_SUBSCRIBED, [
-            'details' => [
-                'socketId' => $connection->socketId,
-                'channel' => $channelName,
-            ],
-        ]);
-    }
+    const TYPE_REPLICATOR_MESSAGE_RECEIVED = 'replicator-message-received';
 
-    public static function clientMessage(ConnectionInterface $connection, stdClass $payload)
-    {
-        static::log($connection->app->id, static::TYPE_CLIENT_MESSAGE, [
-            'details' => [
-                'socketId' => $connection->socketId,
-                'channel' => $payload->channel,
-                'event' => $payload->event,
-                'data' => $payload,
-            ],
-        ]);
-    }
+    /**
+     * The list of all channels.
+     *
+     * @var array
+     */
+    public static $channels = [
+        self::TYPE_DISCONNECTED,
+        self::TYPE_CONNECTED,
+        self::TYPE_VACATED,
+        self::TYPE_OCCUPIED,
+        self::TYPE_SUBSCRIBED,
+        self::TYPE_WS_MESSAGE,
+        self::TYPE_API_MESSAGE,
+        self::TYPE_REPLICATOR_SUBSCRIBED,
+        self::TYPE_REPLICATOR_UNSUBSCRIBED,
+        self::TYPE_REPLICATOR_JOINED_CHANNEL,
+        self::TYPE_REPLICATOR_LEFT_CHANNEL,
+        self::TYPE_REPLICATOR_MESSAGE_PUBLISHED,
+        self::TYPE_REPLICATOR_MESSAGE_RECEIVED,
+    ];
 
-    public static function disconnection(ConnectionInterface $connection)
-    {
-        static::log($connection->app->id, static::TYPE_DISCONNECTION, [
-            'details' => [
-                'socketId' => $connection->socketId,
-            ],
-        ]);
-    }
-
-    public static function vacated(ConnectionInterface $connection, string $channelName)
-    {
-        static::log($connection->app->id, static::TYPE_VACATED, [
-            'details' => [
-                'socketId' => $connection->socketId,
-                'channel' => $channelName,
-            ],
-        ]);
-    }
-
-    public static function apiMessage($appId, string $channel, string $event, string $payload)
-    {
-        static::log($appId, static::TYPE_API_MESSAGE, [
-            'details' => [
-                'channel' => $connection,
-                'event' => $event,
-                'payload' => $payload,
-            ],
-        ]);
-    }
-
-    public static function replicatorSubscribed(string $appId, string $channel, string $serverId)
-    {
-        static::log($appId, static::TYPE_REPLICATOR_SUBSCRIBED, [
-            'details' => [
-                'serverId' => $serverId,
-                'channel' => $channel,
-            ],
-        ]);
-    }
-
-    public static function replicatorUnsubscribed(string $appId, string $channel, string $serverId)
-    {
-        static::log($appId, static::TYPE_REPLICATOR_UNSUBSCRIBED, [
-            'details' => [
-                'serverId' => $serverId,
-                'channel' => $channel,
-            ],
-        ]);
-    }
-
-    public static function log($appId, string $type, array $attributes = [])
+    public static function log($appId, string $type, array $details = [])
     {
         $channelName = static::LOG_CHANNEL_PREFIX.$type;
 
@@ -134,7 +69,8 @@ class DashboardLogger
             'data' => [
                 'type' => $type,
                 'time' => strftime('%H:%M:%S'),
-            ] + $attributes,
+                'details' => $details,
+            ],
         ]);
     }
 }

--- a/src/Dashboard/DashboardLogger.php
+++ b/src/Dashboard/DashboardLogger.php
@@ -3,8 +3,6 @@
 namespace BeyondCode\LaravelWebSockets\Dashboard;
 
 use BeyondCode\LaravelWebSockets\WebSockets\Channels\ChannelManager;
-use Ratchet\ConnectionInterface;
-use stdClass;
 
 class DashboardLogger
 {

--- a/src/Dashboard/Http/Controllers/ShowDashboard.php
+++ b/src/Dashboard/Http/Controllers/ShowDashboard.php
@@ -3,6 +3,7 @@
 namespace BeyondCode\LaravelWebSockets\Dashboard\Http\Controllers;
 
 use BeyondCode\LaravelWebSockets\Apps\AppManager;
+use BeyondCode\LaravelWebSockets\Dashboard\DashboardLogger;
 use Illuminate\Http\Request;
 
 class ShowDashboard
@@ -12,6 +13,8 @@ class ShowDashboard
         return view('websockets::dashboard', [
             'apps' => $apps->all(),
             'port' => config('websockets.dashboard.port', 6001),
+            'channels' => DashboardLogger::$channels,
+            'logPrefix' => DashboardLogger::LOG_CHANNEL_PREFIX,
         ]);
     }
 }

--- a/src/Facades/StatisticsLogger.php
+++ b/src/Facades/StatisticsLogger.php
@@ -6,7 +6,7 @@ use BeyondCode\LaravelWebSockets\Statistics\Logger\StatisticsLogger as Statistic
 use Illuminate\Support\Facades\Facade;
 
 /**
- * @see \BeyondCode\LaravelWebSockets\Statistics\Logger\HttpStatisticsLogger
+ * @see   \BeyondCode\LaravelWebSockets\Statistics\Logger\HttpStatisticsLogger
  * @mixin \BeyondCode\LaravelWebSockets\Statistics\Logger\HttpStatisticsLogger
  */
 class StatisticsLogger extends Facade

--- a/src/HttpApi/Controllers/TriggerEventController.php
+++ b/src/HttpApi/Controllers/TriggerEventController.php
@@ -21,12 +21,11 @@ class TriggerEventController extends Controller
                 'data' => $request->json()->get('data'),
             ], $request->json()->get('socket_id'), $request->appId);
 
-            DashboardLogger::apiMessage(
-                $request->appId,
-                $channelName,
-                $request->json()->get('name'),
-                $request->json()->get('data')
-            );
+            DashboardLogger::log($request->appId, DashboardLogger::TYPE_API_MESSAGE, [
+                'channel' => $channelName,
+                'event' => $request->json()->get('name'),
+                'payload' => $request->json()->get('data'),
+            ]);
 
             StatisticsLogger::apiMessage($request->appId);
         }

--- a/src/PubSub/Drivers/LocalClient.php
+++ b/src/PubSub/Drivers/LocalClient.php
@@ -78,7 +78,7 @@ class LocalClient implements ReplicationInterface
      */
     public function joinChannel(string $appId, string $channel, string $socketId, string $data)
     {
-        $this->channelData["$appId:$channel"][$socketId] = $data;
+        $this->channelData["{$appId}:{$channel}"][$socketId] = $data;
     }
 
     /**
@@ -92,10 +92,10 @@ class LocalClient implements ReplicationInterface
      */
     public function leaveChannel(string $appId, string $channel, string $socketId)
     {
-        unset($this->channelData["$appId:$channel"][$socketId]);
+        unset($this->channelData["{$appId}:{$channel}"][$socketId]);
 
-        if (empty($this->channelData["$appId:$channel"])) {
-            unset($this->channelData["$appId:$channel"]);
+        if (empty($this->channelData["{$appId}:{$channel}"])) {
+            unset($this->channelData["{$appId}:{$channel}"]);
         }
     }
 
@@ -108,7 +108,7 @@ class LocalClient implements ReplicationInterface
      */
     public function channelMembers(string $appId, string $channel): PromiseInterface
     {
-        $members = $this->channelData["$appId:$channel"] ?? [];
+        $members = $this->channelData["{$appId}:{$channel}"] ?? [];
 
         $members = array_map(function ($user) {
             return json_decode($user);
@@ -130,8 +130,8 @@ class LocalClient implements ReplicationInterface
 
         // Count the number of users per channel
         foreach ($channelNames as $channel) {
-            $results[$channel] = isset($this->channelData["$appId:$channel"])
-                ? count($this->channelData["$appId:$channel"])
+            $results[$channel] = isset($this->channelData["{$appId}:{$channel}"])
+                ? count($this->channelData["{$appId}:{$channel}"])
                 : 0;
         }
 

--- a/src/Statistics/Logger/NullStatisticsLogger.php
+++ b/src/Statistics/Logger/NullStatisticsLogger.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace BeyondCode\LaravelWebSockets\Statistics\Logger;
+
+use BeyondCode\LaravelWebSockets\WebSockets\Channels\ChannelManager;
+use Clue\React\Buzz\Browser;
+use Ratchet\ConnectionInterface;
+
+class NullStatisticsLogger implements StatisticsLogger
+{
+    /** @var \BeyondCode\LaravelWebSockets\WebSockets\Channels\ChannelManager */
+    protected $channelManager;
+
+    /** @var \Clue\React\Buzz\Browser */
+    protected $browser;
+
+    public function __construct(ChannelManager $channelManager, Browser $browser)
+    {
+        $this->channelManager = $channelManager;
+        $this->browser = $browser;
+    }
+
+    public function webSocketMessage(ConnectionInterface $connection)
+    {
+        //
+    }
+
+    public function apiMessage($appId)
+    {
+        //
+    }
+
+    public function connection(ConnectionInterface $connection)
+    {
+        //
+    }
+
+    public function disconnection(ConnectionInterface $connection)
+    {
+        //
+    }
+
+    public function save()
+    {
+        //
+    }
+}

--- a/src/WebSockets/Channels/Channel.php
+++ b/src/WebSockets/Channels/Channel.php
@@ -82,7 +82,10 @@ class Channel
         $this->replicator->unsubscribe($connection->app->id, $this->channelName);
 
         if (! $this->hasConnections()) {
-            DashboardLogger::vacated($connection, $this->channelName);
+            DashboardLogger::log($connection->app->id, DashboardLogger::TYPE_VACATED, [
+                'socketId' => $connection->socketId,
+                'channel' => $this->channelName,
+            ]);
         }
     }
 
@@ -93,10 +96,15 @@ class Channel
         $this->subscribedConnections[$connection->socketId] = $connection;
 
         if (! $hadConnectionsPreviously) {
-            DashboardLogger::occupied($connection, $this->channelName);
+            DashboardLogger::log($connection->app->id, DashboardLogger::TYPE_OCCUPIED, [
+                'channel' => $this->channelName,
+            ]);
         }
 
-        DashboardLogger::subscribed($connection, $this->channelName);
+        DashboardLogger::log($connection->app->id, DashboardLogger::TYPE_SUBSCRIBED, [
+            'socketId' => $connection->socketId,
+            'channel' => $this->channelName,
+        ]);
     }
 
     public function broadcast($payload)

--- a/src/WebSockets/Messages/PusherClientMessage.php
+++ b/src/WebSockets/Messages/PusherClientMessage.php
@@ -38,7 +38,12 @@ class PusherClientMessage implements PusherMessage
             return;
         }
 
-        DashboardLogger::clientMessage($this->connection, $this->payload);
+        DashboardLogger::log($this->connection->app->id, DashboardLogger::TYPE_WS_MESSAGE, [
+            'socketId' => $this->connection->socketId,
+            'channel' => $this->payload->channel,
+            'event' => $this->payload->event,
+            'data' => $this->payload,
+        ]);
 
         $channel = $this->channelManager->find($this->connection->app->id, $this->payload->channel);
 

--- a/src/WebSockets/WebSocketHandler.php
+++ b/src/WebSockets/WebSocketHandler.php
@@ -116,6 +116,8 @@ class WebSocketHandler implements MessageComponentInterface
             'socketId' => $connection->socketId,
         ]);
 
+        StatisticsLogger::connection($connection);
+
         return $this;
     }
 }

--- a/src/WebSockets/WebSocketHandler.php
+++ b/src/WebSockets/WebSocketHandler.php
@@ -48,7 +48,9 @@ class WebSocketHandler implements MessageComponentInterface
     {
         $this->channelManager->removeFromAllChannels($connection);
 
-        DashboardLogger::disconnection($connection);
+        DashboardLogger::log($connection->app->id, DashboardLogger::TYPE_DISCONNECTED, [
+            'socketId' => $connection->socketId,
+        ]);
 
         StatisticsLogger::disconnection($connection);
     }
@@ -106,9 +108,13 @@ class WebSocketHandler implements MessageComponentInterface
             ]),
         ]));
 
-        DashboardLogger::connection($connection);
+        /** @var \GuzzleHttp\Psr7\Request $request */
+        $request = $connection->httpRequest;
 
-        StatisticsLogger::connection($connection);
+        DashboardLogger::log($connection->app->id, DashboardLogger::TYPE_CONNECTED, [
+            'origin' => "{$request->getUri()->getScheme()}://{$request->getUri()->getHost()}",
+            'socketId' => $connection->socketId,
+        ]);
 
         return $this;
     }


### PR DESCRIPTION
This PR refactors the dashboard side. From design to how the Dashboard Logger is registering the events throughout the WebSockets server. It also adds a `NullStatisticsLogger` that will void any incoming statistics in case no statistics are needed.

![homestead test_laravel-websockets (1)](https://user-images.githubusercontent.com/21983456/90478678-2d236780-e136-11ea-85e4-c479a932f8a2.png)