### PR TITLE
fix undefined property for unknown app key exception

### DIFF
--- a/src/WebSockets/WebSocketHandler.php
+++ b/src/WebSockets/WebSocketHandler.php
@@ -112,7 +112,9 @@ class WebSocketHandler implements MessageComponentInterface
             ));
         }
 
-        $this->replicator->unsubscribeFromApp($connection->app->id);
+        if (property_exists($connection, 'app')) {
+            $this->replicator->unsubscribeFromApp($connection->app->id);
+        }
     }
 
     /**


### PR DESCRIPTION
When connect to server with a not exist app key, it will throw `UnknownAppKey` exception. 

However, in the mean time, the `$app` is not assigned yet. 

Thus, when unsubscribe from app, it will result in `Undefined property: Ratchet\Server\IoConnection::$app`.