### PR TITLE
[feature] PCNTL signals into soft-close of connections for Redis horizontal replication

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,9 @@
         "orchestra/database": "^4.0|^5.0|^6.0",
         "phpunit/phpunit": "^8.0|^9.0"
     },
+    "suggest": {
+        "ext-pcntl": "Running the server needs pcntl to listen to command signals and soft-shutdown."
+    },
     "autoload": {
         "psr-4": {
             "BeyondCode\\LaravelWebSockets\\": "src/"

--- a/src/ChannelManagers/LocalChannelManager.php
+++ b/src/ChannelManagers/LocalChannelManager.php
@@ -343,6 +343,27 @@ class LocalChannelManager implements ChannelManager
     }
 
     /**
+     * Keep tracking the connections availability when they pong.
+     *
+     * @param  \Ratchet\ConnectionInterface  $connection
+     * @return bool
+     */
+    public function connectionPonged(ConnectionInterface $connection): bool
+    {
+        return true;
+    }
+
+    /**
+     * Remove the obsolete connections that didn't ponged in a while.
+     *
+     * @return bool
+     */
+    public function removeObsoleteConnections(): bool
+    {
+        return true;
+    }
+
+    /**
      * Mark the current instance as unable to accept new connections.
      *
      * @return $this

--- a/src/ChannelManagers/RedisChannelManager.php
+++ b/src/ChannelManagers/RedisChannelManager.php
@@ -68,6 +68,17 @@ class RedisChannelManager extends LocalChannelManager
     }
 
     /**
+     * Get the local connections, regardless of the channel
+     * they are connected to.
+     *
+     * @return \React\Promise\PromiseInterface
+     */
+    public function getLocalConnections(): PromiseInterface
+    {
+        return parent::getLocalConnections();
+    }
+
+    /**
      * Get all channels for a specific app
      * for the current instance.
      *
@@ -108,9 +119,9 @@ class RedisChannelManager extends LocalChannelManager
                         $connection, $channel, new stdClass
                     );
                 }
+            })->then(function () use ($connection) {
+                parent::unsubscribeFromAllChannels($connection);
             });
-
-        parent::unsubscribeFromAllChannels($connection);
     }
 
     /**

--- a/src/ChannelManagers/RedisChannelManager.php
+++ b/src/ChannelManagers/RedisChannelManager.php
@@ -12,7 +12,6 @@ use Illuminate\Cache\RedisLock;
 use Illuminate\Support\Facades\Redis;
 use Illuminate\Support\Str;
 use Ratchet\ConnectionInterface;
-use Ratchet\WebSocket\WsConnection;
 use React\EventLoop\LoopInterface;
 use React\Promise\PromiseInterface;
 use stdClass;

--- a/src/ChannelManagers/RedisChannelManager.php
+++ b/src/ChannelManagers/RedisChannelManager.php
@@ -3,10 +3,16 @@
 namespace BeyondCode\LaravelWebSockets\ChannelManagers;
 
 use BeyondCode\LaravelWebSockets\Channels\Channel;
+use BeyondCode\LaravelWebSockets\Helpers;
+use BeyondCode\LaravelWebSockets\Server\MockableConnection;
+use Carbon\Carbon;
 use Clue\React\Redis\Client;
 use Clue\React\Redis\Factory;
+use Illuminate\Cache\RedisLock;
+use Illuminate\Support\Facades\Redis;
 use Illuminate\Support\Str;
 use Ratchet\ConnectionInterface;
+use Ratchet\WebSocket\WsConnection;
 use React\EventLoop\LoopInterface;
 use React\Promise\PromiseInterface;
 use stdClass;
@@ -42,6 +48,21 @@ class RedisChannelManager extends LocalChannelManager
     protected $subscribeClient;
 
     /**
+     * The Redis manager instance.
+     *
+     * @var \Illuminate\Redis\RedisManager
+     */
+    protected $redis;
+
+    /**
+     * The lock name to use on Redis to avoid multiple
+     * actions that might lead to multiple processings.
+     *
+     * @var string
+     */
+    protected static $redisLockName = 'laravel-websockets:channel-manager:lock';
+
+    /**
      * Create a new channel manager instance.
      *
      * @param  LoopInterface  $loop
@@ -51,6 +72,10 @@ class RedisChannelManager extends LocalChannelManager
     public function __construct(LoopInterface $loop, $factoryClass = null)
     {
         $this->loop = $loop;
+
+        $this->redis = Redis::connection(
+            config('websockets.replication.modes.redis.connection', 'default')
+        );
 
         $connectionUri = $this->getConnectionUri();
 
@@ -141,6 +166,8 @@ class RedisChannelManager extends LocalChannelManager
                 }
             });
 
+        $this->addConnectionToSet($connection);
+
         $this->addChannelToSet(
             $connection->app->id, $channelName
         );
@@ -167,7 +194,13 @@ class RedisChannelManager extends LocalChannelManager
                 if ($count === 0) {
                     $this->unsubscribeFromTopic($connection->app->id, $channelName);
 
+                    $this->removeUserData(
+                        $connection->app->id, $channelName, $connection->socketId
+                    );
+
                     $this->removeChannelFromSet($connection->app->id, $channelName);
+
+                    $this->removeConnectionFromSet($connection);
 
                     return;
                 }
@@ -179,7 +212,13 @@ class RedisChannelManager extends LocalChannelManager
                     if ($count < 1) {
                         $this->unsubscribeFromTopic($connection->app->id, $channelName);
 
+                        $this->removeUserData(
+                            $connection->app->id, $channelName, $connection->socketId
+                        );
+
                         $this->removeChannelFromSet($connection->app->id, $channelName);
+
+                        $this->removeConnectionFromSet($connection);
                     }
                 });
             });
@@ -304,12 +343,8 @@ class RedisChannelManager extends LocalChannelManager
     {
         return $this->publishClient
             ->hgetall($this->getRedisKey($appId, $channel, ['users']))
-            ->then(function ($members) {
-                [$keys, $values] = collect($members)->partition(function ($value, $key) {
-                    return $key % 2 === 0;
-                });
-
-                return collect(array_combine($keys->all(), $values->all()))
+            ->then(function ($list) {
+                return collect(Helpers::redisListToArray($list))
                     ->map(function ($user) {
                         return json_decode($user);
                     })
@@ -353,6 +388,43 @@ class RedisChannelManager extends LocalChannelManager
             ->then(function ($data) use ($channelNames) {
                 return array_combine($channelNames, $data);
             });
+    }
+
+    /**
+     * Keep tracking the connections availability when they pong.
+     *
+     * @param  \Ratchet\ConnectionInterface  $connection
+     * @return bool
+     */
+    public function connectionPonged(ConnectionInterface $connection): bool
+    {
+        // This will update the score with the current timestamp.
+        $this->addConnectionToSet($connection);
+
+        return parent::connectionPonged($connection);
+    }
+
+    /**
+     * Remove the obsolete connections that didn't ponged in a while.
+     *
+     * @return bool
+     */
+    public function removeObsoleteConnections(): bool
+    {
+        $this->lock()->get(function () {
+            $this->getConnectionsFromSet(0, now()->subMinutes(2)->format('U'))
+                ->then(function ($connections) {
+                    foreach ($connections as $connection => $score) {
+                        [$appId, $socketId] = explode(':', $connection);
+
+                        $this->unsubscribeFromAllChannels(
+                            $this->fakeConnectionForApp($appId, $socketId)
+                        );
+                    }
+                });
+        });
+
+        return parent::removeObsoleteConnections();
     }
 
     /**
@@ -474,6 +546,57 @@ class RedisChannelManager extends LocalChannelManager
     }
 
     /**
+     * Add the connection to the sorted list.
+     *
+     * @param  \Ratchet\ConnectionInterface  $connection
+     * @param  \DateTime|string|null  $moment
+     * @return void
+     */
+    public function addConnectionToSet(ConnectionInterface $connection, $moment = null)
+    {
+        $this->getPublishClient()
+            ->zadd(
+                $this->getRedisKey(null, null, ['sockets']),
+                Carbon::parse($moment)->format('U'), "{$connection->app->id}:{$connection->socketId}"
+            );
+    }
+
+    /**
+     * Remove the connection from the sorted list.
+     *
+     * @param  \Ratchet\ConnectionInterface  $connection
+     * @return void
+     */
+    public function removeConnectionFromSet(ConnectionInterface $connection)
+    {
+        $this->getPublishClient()
+            ->zrem(
+                $this->getRedisKey(null, null, ['sockets']),
+                "{$connection->app->id}:{$connection->socketId}"
+            );
+    }
+
+    /**
+     * Get the connections from the sorted list, with last
+     * connection between certain timestamps.
+     *
+     * @param  int  $start
+     * @param  int  $stop
+     * @return PromiseInterface
+     */
+    public function getConnectionsFromSet(int $start = 0, int $stop = 0)
+    {
+        return $this->getPublishClient()
+            ->zrange(
+                $this->getRedisKey(null, null, ['sockets']),
+                $start, $stop, 'withscores'
+            )
+            ->then(function ($list) {
+                return Helpers::redisListToArray($list);
+            });
+    }
+
+    /**
      * Add a channel to the set list.
      *
      * @param  string|int  $appId
@@ -566,11 +689,11 @@ class RedisChannelManager extends LocalChannelManager
      * Get the Redis Keyspace name to handle subscriptions
      * and other key-value sets.
      *
-     * @param  mixed  $appId
+     * @param  string|int|null  $appId
      * @param  string|null  $channel
      * @return string
      */
-    public function getRedisKey($appId, string $channel = null, array $suffixes = []): string
+    public function getRedisKey($appId = null, string $channel = null, array $suffixes = []): string
     {
         $prefix = config('database.redis.options.prefix', null);
 
@@ -587,5 +710,29 @@ class RedisChannelManager extends LocalChannelManager
         }
 
         return $hash;
+    }
+
+    /**
+     * Get a new RedisLock instance to avoid race conditions.
+     *
+     * @return \Illuminate\Cache\CacheLock
+     */
+    protected function lock()
+    {
+        return new RedisLock($this->redis, static::$redisLockName, 0);
+    }
+
+    /**
+     * Create a fake connection for app that will mimick a connection
+     * by app ID and Socket ID to be able to be passed to the methods
+     * that accepts a connection class.
+     *
+     * @param  string|int  $appId
+     * @param  string  $socketId
+     * @return ConnectionInterface
+     */
+    public function fakeConnectionForApp($appId, string $socketId)
+    {
+        return new MockableConnection($appId, $socketId);
     }
 }

--- a/src/Console/Commands/StartServer.php
+++ b/src/Console/Commands/StartServer.php
@@ -26,7 +26,7 @@ class StartServer extends Command
         {--disable-statistics : Disable the statistics tracking.}
         {--statistics-interval= : The amount of seconds to tick between statistics saving.}
         {--debug : Forces the loggers to be enabled and thereby overriding the APP_DEBUG setting.}
-        {--test : Prepare the server, but do not start it.}
+        {--loop : Programatically inject the loop.}
     ';
 
     /**
@@ -78,6 +78,8 @@ class StartServer extends Command
         $this->configureRestartTimer();
 
         $this->configureRoutes();
+
+        $this->configurePcntlSignal();
 
         $this->startServer();
     }
@@ -157,6 +159,31 @@ class StartServer extends Command
     }
 
     /**
+     * Configure the PCNTL signals for soft shutdown.
+     *
+     * @return void
+     */
+    protected function configurePcntlSignal()
+    {
+        // When the process receives a SIGTERM or a SIGINT
+        // signal, it should mark the server as unavailable
+        // to receive new connections, close the current connections,
+        // then stopping the loop.
+
+        $this->loop->addSignal(SIGTERM, function () {
+            $this->line('Closing existing connections...');
+
+            $this->triggerSoftShutdown();
+        });
+
+        $this->loop->addSignal(SIGINT, function () {
+            $this->line('Closing existing connections...');
+
+            $this->triggerSoftShutdown();
+        });
+    }
+
+    /**
      * Configure the HTTP logger class.
      *
      * @return void
@@ -209,14 +236,6 @@ class StartServer extends Command
 
         $this->buildServer();
 
-        // For testing, just boot up the server, run it
-        // but exit after the next tick.
-        if ($this->option('test')) {
-            $this->loop->futureTick(function () {
-                $this->loop->stop();
-            });
-        }
-
         $this->server->run();
     }
 
@@ -230,6 +249,10 @@ class StartServer extends Command
         $this->server = new ServerFactory(
             $this->option('host'), $this->option('port')
         );
+
+        if ($loop = $this->option('loop')) {
+            $this->loop = $loop;
+        }
 
         $this->server = $this->server
             ->setLoop($this->loop)
@@ -248,5 +271,30 @@ class StartServer extends Command
         return Cache::get(
             'beyondcode:websockets:restart', 0
         );
+    }
+
+    /**
+     * Trigger a soft shutdown for the process.
+     *
+     * @return void
+     */
+    protected function triggerSoftShutdown()
+    {
+        $channelManager = $this->laravel->make(ChannelManager::class);
+
+        // Close the new connections allowance on this server.
+        $channelManager->declineNewConnections();
+
+        // Get all local connections and close them. They will
+        // be automatically be unsubscribed from all channels.
+        $channelManager->getLocalConnections()
+            ->then(function ($connections) use ($channelManager) {
+                foreach ($connections as $connection) {
+                    $connection->close();
+                }
+            })
+            ->then(function () {
+                $this->loop->stop();
+            });
     }
 }

--- a/src/Console/Commands/StartServer.php
+++ b/src/Console/Commands/StartServer.php
@@ -288,7 +288,7 @@ class StartServer extends Command
         // Get all local connections and close them. They will
         // be automatically be unsubscribed from all channels.
         $channelManager->getLocalConnections()
-            ->then(function ($connections) use ($channelManager) {
+            ->then(function ($connections) {
                 foreach ($connections as $connection) {
                     $connection->close();
                 }

--- a/src/Console/Commands/StartServer.php
+++ b/src/Console/Commands/StartServer.php
@@ -81,6 +81,8 @@ class StartServer extends Command
 
         $this->configurePcntlSignal();
 
+        $this->configurePongTracker();
+
         $this->startServer();
     }
 
@@ -180,6 +182,21 @@ class StartServer extends Command
             $this->line('Closing existing connections...');
 
             $this->triggerSoftShutdown();
+        });
+    }
+
+    /**
+     * Configure the tracker that will delete
+     * from the store the connections that
+     *
+     * @return void
+     */
+    protected function configurePongTracker()
+    {
+        $this->loop->addPeriodicTimer(10, function () {
+            $this->laravel
+                ->make(ChannelManager::class)
+                ->removeObsoleteConnections();
         });
     }
 

--- a/src/Console/Commands/StartServer.php
+++ b/src/Console/Commands/StartServer.php
@@ -187,7 +187,7 @@ class StartServer extends Command
 
     /**
      * Configure the tracker that will delete
-     * from the store the connections that
+     * from the store the connections that.
      *
      * @return void
      */

--- a/src/Console/Commands/StartServer.php
+++ b/src/Console/Commands/StartServer.php
@@ -143,7 +143,7 @@ class StartServer extends Command
 
         $this->loop->addPeriodicTimer(10, function () {
             if ($this->getLastRestart() !== $this->lastRestart) {
-                $this->loop->stop();
+                $this->triggerSoftShutdown();
             }
         });
     }

--- a/src/Contracts/ChannelManager.php
+++ b/src/Contracts/ChannelManager.php
@@ -37,6 +37,14 @@ interface ChannelManager
     public function findOrCreate($appId, string $channel);
 
     /**
+     * Get the local connections, regardless of the channel
+     * they are connected to.
+     *
+     * @return \React\Promise\PromiseInterface
+     */
+    public function getLocalConnections(): PromiseInterface;
+
+    /**
      * Get all channels for a specific app
      * for the current instance.
      *

--- a/src/Contracts/ChannelManager.php
+++ b/src/Contracts/ChannelManager.php
@@ -185,4 +185,19 @@ interface ChannelManager
      * @return \React\Promise\PromiseInterface
      */
     public function getChannelsMembersCount($appId, array $channelNames): PromiseInterface;
+
+    /**
+     * Keep tracking the connections availability when they pong.
+     *
+     * @param  \Ratchet\ConnectionInterface  $connection
+     * @return bool
+     */
+    public function connectionPonged(ConnectionInterface $connection): bool;
+
+    /**
+     * Remove the obsolete connections that didn't ponged in a while.
+     *
+     * @return bool
+     */
+    public function removeObsoleteConnections(): bool;
 }

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace BeyondCode\LaravelWebSockets;
+
+class Helpers
+{
+    /**
+     * Transform the Redis' list of key after value
+     * to key-value pairs.
+     *
+     * @param  array  $list
+     * @return array
+     */
+    public static function redisListToArray(array $list)
+    {
+        // Redis lists come into a format where the keys are on even indexes
+        // and the values are on odd indexes. This way, we know which
+        // ones are keys and which ones are values and their get combined
+        // later to form the key => value array.
+        [$keys, $values] = collect($list)->partition(function ($value, $key) {
+            return $key % 2 === 0;
+        });
+
+        return array_combine($keys->all(), $values->all());
+    }
+}

--- a/src/Server/Messages/PusherChannelProtocolMessage.php
+++ b/src/Server/Messages/PusherChannelProtocolMessage.php
@@ -34,6 +34,8 @@ class PusherChannelProtocolMessage extends PusherClientMessage
         $connection->send(json_encode([
             'event' => 'pusher:pong',
         ]));
+
+        $this->channelManager->connectionPonged($connection);
     }
 
     /**

--- a/src/Server/MockableConnection.php
+++ b/src/Server/MockableConnection.php
@@ -24,6 +24,7 @@ class MockableConnection implements ConnectionInterface
 
     /**
      * Send data to the connection.
+     *
      * @param  string  $data
      * @return \Ratchet\ConnectionInterface
      */

--- a/src/Server/MockableConnection.php
+++ b/src/Server/MockableConnection.php
@@ -23,21 +23,21 @@ class MockableConnection implements ConnectionInterface
     }
 
     /**
-     * Send data to the connection
+     * Send data to the connection.
      * @param  string  $data
      * @return \Ratchet\ConnectionInterface
      */
-    function send($data)
+    public function send($data)
     {
         //
     }
 
     /**
-     * Close the connection
+     * Close the connection.
      *
      * @return void
      */
-    function close()
+    public function close()
     {
         //
     }

--- a/src/Server/MockableConnection.php
+++ b/src/Server/MockableConnection.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace BeyondCode\LaravelWebSockets\Server;
+
+use Ratchet\ConnectionInterface;
+use stdClass;
+
+class MockableConnection implements ConnectionInterface
+{
+    /**
+     * Create a new Mockable connection.
+     *
+     * @param  string|int  $appId
+     * @param  string  $socketId
+     * @return void
+     */
+    public function __construct($appId, string $socketId)
+    {
+        $this->app = new stdClass;
+
+        $this->app->id = $appId;
+        $this->socketId = $socketId;
+    }
+
+    /**
+     * Send data to the connection
+     * @param  string  $data
+     * @return \Ratchet\ConnectionInterface
+     */
+    function send($data)
+    {
+        //
+    }
+
+    /**
+     * Close the connection
+     *
+     * @return void
+     */
+    function close()
+    {
+        //
+    }
+}

--- a/src/Server/WebSocketHandler.php
+++ b/src/Server/WebSocketHandler.php
@@ -39,6 +39,10 @@ class WebSocketHandler implements MessageComponentInterface
      */
     public function onOpen(ConnectionInterface $connection)
     {
+        if (! $this->connectionCanBeMade($connection)) {
+            return $connection->close();
+        }
+
         $this->verifyAppKey($connection)
             ->verifyOrigin($connection)
             ->limitConcurrentConnections($connection)
@@ -69,6 +73,10 @@ class WebSocketHandler implements MessageComponentInterface
      */
     public function onMessage(ConnectionInterface $connection, MessageInterface $message)
     {
+        if (! isset($connection->app)) {
+            return;
+        }
+
         Messages\PusherMessageFactory::createForMessage(
             $message, $connection, $this->channelManager
         )->respond();
@@ -111,6 +119,18 @@ class WebSocketHandler implements MessageComponentInterface
                 $exception->getPayload()
             ));
         }
+    }
+
+    /**
+     * Check if the connection can be made for the
+     * current server instance.
+     *
+     * @param  \Ratchet\ConnectionInterface  $connection
+     * @return bool
+     */
+    protected function connectionCanBeMade(ConnectionInterface $connection): bool
+    {
+        return $this->channelManager->acceptsNewConnections();
     }
 
     /**

--- a/tests/Commands/StartServerTest.php
+++ b/tests/Commands/StartServerTest.php
@@ -8,7 +8,43 @@ class StartServerTest extends TestCase
 {
     public function test_does_not_fail_if_building_up()
     {
-        $this->artisan('websockets:serve', ['--test' => true, '--debug' => true]);
+        $this->loop->futureTick(function () {
+            $this->loop->stop();
+        });
+
+        $this->artisan('websockets:serve', ['--loop' => $this->loop, '--debug' => true, '--port' => 6001]);
+
+        $this->assertTrue(true);
+    }
+
+    public function test_pcntl_sigint_signal()
+    {
+        $this->loop->futureTick(function () {
+            $this->newActiveConnection(['public-channel']);
+            $this->newActiveConnection(['public-channel']);
+
+            posix_kill(posix_getpid(), SIGINT);
+
+            $this->loop->stop();
+        });
+
+        $this->artisan('websockets:serve', ['--loop' => $this->loop, '--debug' => true, '--port' => 6002]);
+
+        $this->assertTrue(true);
+    }
+
+    public function test_pcntl_sigterm_signal()
+    {
+        $this->loop->futureTick(function () {
+            $this->newActiveConnection(['public-channel']);
+            $this->newActiveConnection(['public-channel']);
+
+            posix_kill(posix_getpid(), SIGTERM);
+
+            $this->loop->stop();
+        });
+
+        $this->artisan('websockets:serve', ['--loop' => $this->loop, '--debug' => true, '--port' => 6003]);
 
         $this->assertTrue(true);
     }

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -111,9 +111,8 @@ class ConnectionTest extends TestCase
 
     public function test_close_all_new_connections_after_stating_the_server_does_not_accept_new_connections()
     {
-        $allowedConnection = $this->newActiveConnection(['test-channel']);
-
-        $allowedConnection->assertSentEvent('pusher:connection_established')
+        $this->newActiveConnection(['test-channel'])
+            ->assertSentEvent('pusher:connection_established')
             ->assertSentEvent('pusher_internal:subscription_succeeded');
 
         $this->channelManager->declineNewConnections();

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -108,4 +108,22 @@ class ConnectionTest extends TestCase
             ->assertSentEvent('pusher:error', ['data' => ['message' => 'Over capacity', 'code' => 4100]])
             ->assertClosed();
     }
+
+    public function test_close_all_new_connections_after_stating_the_server_does_not_accept_new_connections()
+    {
+        $allowedConnection = $this->newActiveConnection(['test-channel']);
+
+        $allowedConnection->assertSentEvent('pusher:connection_established')
+            ->assertSentEvent('pusher_internal:subscription_succeeded');
+
+        $this->channelManager->declineNewConnections();
+
+        $this->assertFalse(
+            $this->channelManager->acceptsNewConnections()
+        );
+
+        $this->newActiveConnection(['test-channel'])
+            ->assertNothingSent()
+            ->assertClosed();
+    }
 }

--- a/tests/Mocks/Connection.php
+++ b/tests/Mocks/Connection.php
@@ -98,6 +98,18 @@ class Connection implements ConnectionInterface
     }
 
     /**
+     * Assert that no events occured within the connection.
+     *
+     * @return $this
+     */
+    public function assertNothingSent()
+    {
+        PHPUnit::assertEquals([], $this->sentData);
+
+        return $this;
+    }
+
+    /**
      * Assert the connection is closed.
      *
      * @return $this

--- a/tests/PresenceChannelTest.php
+++ b/tests/PresenceChannelTest.php
@@ -3,6 +3,7 @@
 namespace BeyondCode\LaravelWebSockets\Test;
 
 use BeyondCode\LaravelWebSockets\Server\Exceptions\InvalidSignature;
+use Ratchet\ConnectionInterface;
 
 class PresenceChannelTest extends TestCase
 {
@@ -183,6 +184,24 @@ class PresenceChannelTest extends TestCase
                     'api_messages_count' => 0,
                     'app_id' => '1234',
                 ], $statistic->toArray());
+            });
+    }
+
+    public function test_local_connections_for_private_channels()
+    {
+        $this->newPresenceConnection('presence-channel', ['user_id' => 1]);
+        $this->newPresenceConnection('presence-channel-2', ['user_id' => 2]);
+
+        $this->channelManager
+            ->getLocalConnections()
+            ->then(function ($connections) {
+                $this->assertCount(2, $connections);
+
+                foreach ($connections as $connection) {
+                    $this->assertInstanceOf(
+                        ConnectionInterface::class, $connection
+                    );
+                }
             });
     }
 }

--- a/tests/PrivateChannelTest.php
+++ b/tests/PrivateChannelTest.php
@@ -3,6 +3,7 @@
 namespace BeyondCode\LaravelWebSockets\Test;
 
 use BeyondCode\LaravelWebSockets\Server\Exceptions\InvalidSignature;
+use Ratchet\ConnectionInterface;
 
 class PrivateChannelTest extends TestCase
 {
@@ -136,6 +137,24 @@ class PrivateChannelTest extends TestCase
                     'api_messages_count' => 0,
                     'app_id' => '1234',
                 ], $statistic->toArray());
+            });
+    }
+
+    public function test_local_connections_for_private_channels()
+    {
+        $this->newPrivateConnection('private-channel');
+        $this->newPrivateConnection('private-channel-2');
+
+        $this->channelManager
+            ->getLocalConnections()
+            ->then(function ($connections) {
+                $this->assertCount(2, $connections);
+
+                foreach ($connections as $connection) {
+                    $this->assertInstanceOf(
+                        ConnectionInterface::class, $connection
+                    );
+                }
             });
     }
 }

--- a/tests/PublicChannelTest.php
+++ b/tests/PublicChannelTest.php
@@ -2,6 +2,8 @@
 
 namespace BeyondCode\LaravelWebSockets\Test;
 
+use Ratchet\ConnectionInterface;
+
 class PublicChannelTest extends TestCase
 {
     public function test_connect_to_public_channel()
@@ -112,6 +114,24 @@ class PublicChannelTest extends TestCase
                     'api_messages_count' => 0,
                     'app_id' => '1234',
                 ], $statistic->toArray());
+            });
+    }
+
+    public function test_local_connections_for_public_channels()
+    {
+        $this->newActiveConnection(['public-channel']);
+        $this->newActiveConnection(['public-channel-2']);
+
+        $this->channelManager
+            ->getLocalConnections()
+            ->then(function ($connections) {
+                $this->assertCount(2, $connections);
+
+                foreach ($connections as $connection) {
+                    $this->assertInstanceOf(
+                        ConnectionInterface::class, $connection
+                    );
+                }
             });
     }
 }


### PR DESCRIPTION
Since the horizontal replication stores some of the presence channels data and the connection IDs in Redis, if the server abruptly closes, the Redis data might still be persistent.

In this PR, I came up with a first gate on which upon SIGINT/SIGTERM, the entire connections list gets closed, but not before the server marks itself as being unable to accept new connections, while the current connections are closed and the process finally terminates.

This is definitely not ideal but as the first gate on termination protection, it should be enough until I come up with another idea on how to expire the data within the Redis sets between ping-pongs (so if the user doesn't ping anymore, it will let the Redis DB invalidate the key associated to that connection).

Additionally, since whenever one server gets interrupted and loses the local data and Redis still keep tracking of the old data unless the PCNTL signal gets read properly, it will loop through the expired connections from the sorted list in Redis, and will expire all connections that didn't pong in the last 2 minutes (120 seconds) according to the pusher protocol: https://pusher.com/docs/channels/library_auth_reference/pusher-websockets-protocol#recommendations-for-client-libraries
