### PR TITLE
Fix presence channels double counting users

### DIFF
--- a/src/WebSockets/Channels/PresenceChannel.php
+++ b/src/WebSockets/Channels/PresenceChannel.php
@@ -63,9 +63,9 @@ class PresenceChannel extends Channel
     {
         return [
             'presence' => [
-                'ids' => $this->getUserIds(),
+                'ids' => $userIds = $this->getUserIds(),
                 'hash' => $this->getHash(),
-                'count' => count($this->users),
+                'count' => count($userIds),
             ],
         ];
     }
@@ -73,7 +73,7 @@ class PresenceChannel extends Channel
     public function toArray(): array
     {
         return array_merge(parent::toArray(), [
-            'user_count' => count($this->users),
+            'user_count' => count($this->getUserIds()),
         ]);
     }
 
@@ -83,7 +83,7 @@ class PresenceChannel extends Channel
             return (string) $channelData->user_id;
         }, $this->users);
 
-        return array_values($userIds);
+        return array_values(array_unique($userIds));
     }
 
     /**

--- a/tests/Channels/PresenceChannelTest.php
+++ b/tests/Channels/PresenceChannelTest.php
@@ -90,9 +90,9 @@ class PresenceChannelTest extends TestCase
             'channel' => $channelName,
             'data' => json_encode([
                 'presence' => [
-                    'ids' => [(string)$userId],
+                    'ids' => [(string) $userId],
                     'hash' => [
-                        (string)$userId => [],
+                        (string) $userId => [],
                     ],
                     'count' => 1,
                 ],
@@ -102,12 +102,12 @@ class PresenceChannelTest extends TestCase
 
     private function getSignedMessage(Connection $connection, string $channelName, array $channelData): Message
     {
-        $signature = "{$connection->socketId}:{$channelName}:" . json_encode($channelData);
+        $signature = "{$connection->socketId}:{$channelName}:".json_encode($channelData);
 
         return new Message(json_encode([
             'event' => 'pusher:subscribe',
             'data' => [
-                'auth' => $connection->app->key . ':' . hash_hmac('sha256', $signature, $connection->app->secret),
+                'auth' => $connection->app->key.':'.hash_hmac('sha256', $signature, $connection->app->secret),
                 'channel' => $channelName,
                 'channel_data' => json_encode($channelData),
             ],

--- a/tests/Channels/PresenceChannelTest.php
+++ b/tests/Channels/PresenceChannelTest.php
@@ -2,6 +2,7 @@
 
 namespace BeyondCode\LaravelWebSockets\Tests\Channels;
 
+use BeyondCode\LaravelWebSockets\Tests\Mocks\Connection;
 use BeyondCode\LaravelWebSockets\Tests\Mocks\Message;
 use BeyondCode\LaravelWebSockets\Tests\TestCase;
 use BeyondCode\LaravelWebSockets\WebSockets\Exceptions\InvalidSignature;
@@ -42,16 +43,7 @@ class PresenceChannelTest extends TestCase
             ],
         ];
 
-        $signature = "{$connection->socketId}:presence-channel:".json_encode($channelData);
-
-        $message = new Message(json_encode([
-            'event' => 'pusher:subscribe',
-            'data' => [
-                'auth' => $connection->app->key.':'.hash_hmac('sha256', $signature, $connection->app->secret),
-                'channel' => 'presence-channel',
-                'channel_data' => json_encode($channelData),
-            ],
-        ]));
+        $message = $this->getSignedMessage($connection, 'presence-channel', $channelData);
 
         $this->pusherServer->onMessage($connection, $message);
 
@@ -71,21 +63,54 @@ class PresenceChannelTest extends TestCase
             'user_id' => 1,
         ];
 
-        $signature = "{$connection->socketId}:presence-channel:".json_encode($channelData);
-
-        $message = new Message(json_encode([
-            'event' => 'pusher:subscribe',
-            'data' => [
-                'auth' => $connection->app->key.':'.hash_hmac('sha256', $signature, $connection->app->secret),
-                'channel' => 'presence-channel',
-                'channel_data' => json_encode($channelData),
-            ],
-        ]));
+        $message = $this->getSignedMessage($connection, 'presence-channel', $channelData);
 
         $this->pusherServer->onMessage($connection, $message);
 
         $connection->assertSentEvent('pusher_internal:subscription_succeeded', [
             'channel' => 'presence-channel',
         ]);
+    }
+
+    /** @test */
+    public function multiple_clients_with_same_user_id_are_counted_once()
+    {
+        $this->pusherServer->onOpen($connection = $this->getWebSocketConnection());
+        $this->pusherServer->onOpen($connection2 = $this->getWebSocketConnection());
+
+        $channelName = 'presence-channel';
+        $channelData = [
+            'user_id' => $userId = 1,
+        ];
+
+        $this->pusherServer->onMessage($connection, $this->getSignedMessage($connection, $channelName, $channelData));
+        $this->pusherServer->onMessage($connection2, $this->getSignedMessage($connection2, $channelName, $channelData));
+
+        $connection2->assertSentEvent('pusher_internal:subscription_succeeded', [
+            'channel' => $channelName,
+            'data' => json_encode([
+                'presence' => [
+                    'ids' => [(string)$userId],
+                    'hash' => [
+                        (string)$userId => [],
+                    ],
+                    'count' => 1,
+                ],
+            ]),
+        ]);
+    }
+
+    private function getSignedMessage(Connection $connection, string $channelName, array $channelData): Message
+    {
+        $signature = "{$connection->socketId}:{$channelName}:" . json_encode($channelData);
+
+        return new Message(json_encode([
+            'event' => 'pusher:subscribe',
+            'data' => [
+                'auth' => $connection->app->key . ':' . hash_hmac('sha256', $signature, $connection->app->secret),
+                'channel' => $channelName,
+                'channel_data' => json_encode($channelData),
+            ],
+        ]));
     }
 }


### PR DESCRIPTION
I know 2.x is under way but it would be nice to have 1.x in a working state and this is quite the bug 😄 

**What is happening?**
Presence channels are double counting unique users because it's counting socket ID's.

**How does Pusher handle this?**
Pusher uses the `user_id` property to uniquely count the users in a presence channel.

**Does this PR fix that?**
Well, yes 😉 

**Okay, so why are the tests failing?**
See: #528.

Would be great to see this released on 1.x.