### PR TITLE
Fix test suite

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,6 +19,9 @@ jobs:
                         testbench: 5.*
                     -   laravel: 6.*
                         testbench: 4.*
+                exclude:
+                    -   php: 7.2
+                        laravel: 8.*
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -39,7 +39,7 @@ jobs:
                 uses: shivammathur/setup-php@v2
                 with:
                     php-version: ${{ matrix.php }}
-                    extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
+                    extensions: curl, dom, libxml, mbstring, pdo, sqlite, pdo_sqlite, zip
                     coverage: pcov
 
             -   name: Install dependencies


### PR DESCRIPTION
Do not test Laravel 8 on PHP 7.2.

Master is now failing including any new PR because Laravel 8 requires PHP 7.3+.

As a bonus I removed some PHP extension that are not needed to run the testsuite speeding up the suite a bit.