### PR TITLE
Fix presence channels emitting too much events

### DIFF
--- a/src/HttpApi/Controllers/FetchUsersController.php
+++ b/src/HttpApi/Controllers/FetchUsersController.php
@@ -22,8 +22,8 @@ class FetchUsersController extends Controller
         }
 
         return [
-            'users' => Collection::make($channel->getUsers())->map(function ($user) {
-                return ['id' => $user->user_id];
+            'users' => Collection::make($channel->getUsers())->keys()->map(function ($userId) {
+                return ['id' => $userId];
             })->values(),
         ];
     }

--- a/src/WebSockets/Channels/PresenceChannel.php
+++ b/src/WebSockets/Channels/PresenceChannel.php
@@ -5,26 +5,44 @@ namespace BeyondCode\LaravelWebSockets\WebSockets\Channels;
 use Ratchet\ConnectionInterface;
 use stdClass;
 
+/**
+ * @link https://pusher.com/docs/pusher_protocol#presence-channel-events
+ */
 class PresenceChannel extends Channel
 {
+    /**
+     * List of users in the channel keyed by their user ID with their info as value.
+     *
+     * @var array<string, array>
+     */
     protected $users = [];
 
-    public function getUsers(): array
-    {
-        return $this->users;
-    }
-
-    /*
-     * @link https://pusher.com/docs/pusher_protocol#presence-channel-events
+    /**
+     * List of sockets keyed by their ID with the value pointing to a user ID.
+     *
+     * @var array<string, string>
      */
+    protected $sockets = [];
+
     public function subscribe(ConnectionInterface $connection, stdClass $payload)
     {
         $this->verifySignature($connection, $payload);
 
         $this->saveConnection($connection);
 
-        $channelData = json_decode($payload->channel_data);
-        $this->users[$connection->socketId] = $channelData;
+        $channelData = json_decode($payload->channel_data, true);
+
+        // The ID of the user connecting
+        $userId = (string) $channelData['user_id'];
+
+        // Check if the user was already connected to the channel before storing the connection in the state
+        $userFirstConnection = ! isset($this->users[$userId]);
+
+        // Add or replace the user info in the state
+        $this->users[$userId] = $channelData['user_info'] ?? [];
+
+        // Add the socket ID to user ID map in the state
+        $this->sockets[$connection->socketId] = $userId;
 
         // Send the success event
         $connection->send(json_encode([
@@ -33,72 +51,74 @@ class PresenceChannel extends Channel
             'data' => json_encode($this->getChannelData()),
         ]));
 
-        $this->broadcastToOthers($connection, [
-            'event' => 'pusher_internal:member_added',
-            'channel' => $this->channelName,
-            'data' => json_encode($channelData),
-        ]);
+        // The `pusher_internal:member_added` event is triggered when a user joins a channel.
+        // It's quite possible that a user can have multiple connections to the same channel
+        // (for example by having multiple browser tabs open)
+        // and in this case the events will only be triggered when the first tab is opened.
+        if ($userFirstConnection) {
+            $this->broadcastToOthers($connection, [
+                'event' => 'pusher_internal:member_added',
+                'channel' => $this->channelName,
+                'data' => json_encode($channelData),
+            ]);
+        }
     }
 
     public function unsubscribe(ConnectionInterface $connection)
     {
         parent::unsubscribe($connection);
 
-        if (! isset($this->users[$connection->socketId])) {
+        if (! isset($this->sockets[$connection->socketId])) {
             return;
         }
 
-        $this->broadcastToOthers($connection, [
-            'event' => 'pusher_internal:member_removed',
-            'channel' => $this->channelName,
-            'data' => json_encode([
-                'user_id' => $this->users[$connection->socketId]->user_id,
-            ]),
-        ]);
+        // Find the user ID belonging to this socket
+        $userId = $this->sockets[$connection->socketId];
 
-        unset($this->users[$connection->socketId]);
+        // Remove the socket from the state
+        unset($this->sockets[$connection->socketId]);
+
+        // Test if the user still has open sockets to this channel
+        $userHasOpenConnections = (array_flip($this->sockets)[$userId] ?? null) !== null;
+
+        // The `pusher_internal:member_removed` is triggered when a user leaves a channel.
+        // It's quite possible that a user can have multiple connections to the same channel
+        // (for example by having multiple browser tabs open)
+        // and in this case the events will only be triggered when the last one is closed.
+        if (! $userHasOpenConnections) {
+            $this->broadcastToOthers($connection, [
+                'event' => 'pusher_internal:member_removed',
+                'channel' => $this->channelName,
+                'data' => json_encode([
+                    'user_id' => $userId,
+                ]),
+            ]);
+
+            // Remove the user info from the state
+            unset($this->users[$userId]);
+        }
     }
 
     protected function getChannelData(): array
     {
         return [
             'presence' => [
-                'ids' => $userIds = $this->getUserIds(),
-                'hash' => $this->getHash(),
-                'count' => count($userIds),
+                'ids' => array_keys($this->users),
+                'hash' => $this->users,
+                'count' => count($this->users),
             ],
         ];
+    }
+
+    public function getUsers(): array
+    {
+        return $this->users;
     }
 
     public function toArray(): array
     {
         return array_merge(parent::toArray(), [
-            'user_count' => count($this->getUserIds()),
+            'user_count' => count($this->users),
         ]);
-    }
-
-    protected function getUserIds(): array
-    {
-        $userIds = array_map(function ($channelData) {
-            return (string) $channelData->user_id;
-        }, $this->users);
-
-        return array_values(array_unique($userIds));
-    }
-
-    /**
-     * Compute the hash for the presence channel integrity.
-     *
-     * @return array
-     */
-    protected function getHash(): array
-    {
-        $hash = [];
-
-        foreach ($this->users as $socketId => $channelData) {
-            $hash[$channelData->user_id] = $channelData->user_info ?? [];
-        }
-
-        return $hash;
     }
 }

--- a/tests/HttpApi/FetchChannelTest.php
+++ b/tests/HttpApi/FetchChannelTest.php
@@ -67,6 +67,39 @@ class FetchChannelTest extends TestCase
     }
 
     /** @test */
+    public function it_returns_the_channel_information_for_presence_channel()
+    {
+        $this->joinPresenceChannel('presence-global', 'user:1');
+        $this->joinPresenceChannel('presence-global', 'user:2');
+        $this->joinPresenceChannel('presence-global', 'user:2');
+
+        $connection = new Connection();
+
+        $requestPath = "/apps/1234/channel/presence-global";
+        $routeParams = [
+            'appId' => '1234',
+            'channelName' => 'presence-global',
+        ];
+
+        $queryString = Pusher::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath);
+
+        $request = new Request('GET', "{$requestPath}?{$queryString}&".http_build_query($routeParams));
+
+        $controller = app(FetchChannelController::class);
+
+        $controller->onOpen($connection, $request);
+
+        /** @var JsonResponse $response */
+        $response = array_pop($connection->sentRawData);
+
+        $this->assertSame([
+            'occupied' => true,
+            'subscription_count' => 3,
+            'user_count' => 2,
+        ], json_decode($response->getContent(), true));
+    }
+
+    /** @test */
     public function it_returns_404_for_invalid_channels()
     {
         $this->expectException(HttpException::class);

--- a/tests/HttpApi/FetchChannelTest.php
+++ b/tests/HttpApi/FetchChannelTest.php
@@ -75,7 +75,7 @@ class FetchChannelTest extends TestCase
 
         $connection = new Connection();
 
-        $requestPath = "/apps/1234/channel/presence-global";
+        $requestPath = '/apps/1234/channel/presence-global';
         $routeParams = [
             'appId' => '1234',
             'channelName' => 'presence-global',

--- a/tests/HttpApi/FetchChannelsTest.php
+++ b/tests/HttpApi/FetchChannelsTest.php
@@ -103,10 +103,10 @@ class FetchChannelsTest extends TestCase
     /** @test */
     public function it_returns_the_channel_information_for_prefix_with_user_count()
     {
-        $this->joinPresenceChannel('presence-global.1');
-        $this->joinPresenceChannel('presence-global.1');
-        $this->joinPresenceChannel('presence-global.2');
-        $this->joinPresenceChannel('presence-notglobal.2');
+        $this->joinPresenceChannel('presence-global.1', 'user:1');
+        $this->joinPresenceChannel('presence-global.1', 'user:2');
+        $this->joinPresenceChannel('presence-global.2', 'user:3');
+        $this->joinPresenceChannel('presence-notglobal.2', 'user:4');
 
         $connection = new Connection();
 

--- a/tests/Mocks/Connection.php
+++ b/tests/Mocks/Connection.php
@@ -28,6 +28,12 @@ class Connection implements ConnectionInterface
         $this->closed = true;
     }
 
+    public function resetEvents()
+    {
+        $this->sentData = [];
+        $this->sentRawData = [];
+    }
+
     public function assertSentEvent(string $name, array $additionalParameters = [])
     {
         $event = collect($this->sentData)->firstWhere('event', '=', $name);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -89,14 +89,14 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
         return $connection;
     }
 
-    protected function joinPresenceChannel($channel): Connection
+    protected function joinPresenceChannel($channel, $userId = null): Connection
     {
         $connection = $this->getWebSocketConnection();
 
         $this->pusherServer->onOpen($connection);
 
         $channelData = [
-            'user_id' => 1,
+            'user_id' => $userId ?? 1,
             'user_info' => [
                 'name' => 'Marcel',
             ],


### PR DESCRIPTION
So after #527 I noticed the counts were still wrong in my app. Dangit I thought this must be my stupid JavaScript code not counting correctly. As it turns out it was not 😄  (that does not happen often).

Pusher only fires `member_added` and `member_removed` events after the first and last socket connection for a user ID. This library would always emit a `member_added` event regardless how many times the user was already connected (same for `member_removed`). This PR aims to fix that behaviour. 

Please go over it to make sure it's correct. The tests should prove that it works, but please make sure I've interpreted the Pusher docs correctly and the tests validate the correct behaviour.

This might technically be a breaking change so not sure this could be 1.8 although it would be very nice to still have this in 1.x before the big refactor of 2.x.

---

There is 1 important consideration for this PR (related to #401). The channel member `user_info` is updated on every new connection, so technically be re-subscribing to the presence channel you can update your user info, I think this is fine, but Pusher handles this differently and it would be trivial to implement that and make the user info "immutable" until all sockets for a user have been disconnected like Pusher... bit torn about this one. Could possibly become a config option?