### PR TITLE
Fix Uncaught TypeError: Cannot read property 'data' of undefined.

### DIFF
--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -314,7 +314,7 @@
         });
 
         this.pusher.connection.bind('error', event => {
-          if (event.error.data.code === 4100) {
+          if (event.data.code === 4100) {
             this.connected = false;
             this.logs = [];
             this.chart = null;


### PR DESCRIPTION
On the error, the event has the following structure. 
```
{type: "PusherError", data: {…}}
data: {code: 1006, message: undefined}
type: "PusherError"
__proto__: Object
```

Since we are trying to access the error key inside the event. it was throwing the undefined error. 