### PR TITLE
Fix wrong redis replication connection config path

### DIFF
--- a/src/ChannelManagers/RedisChannelManager.php
+++ b/src/ChannelManagers/RedisChannelManager.php
@@ -487,7 +487,7 @@ class RedisChannelManager extends LocalChannelManager
      */
     protected function getConnectionUri()
     {
-        $name = config('websockets.replication.redis.connection', 'default');
+        $name = config('websockets.replication.modes.redis.connection', 'default');
         $config = config("database.redis.{$name}");
 
         $host = $config['host'];

--- a/src/ChannelManagers/RedisChannelManager.php
+++ b/src/ChannelManagers/RedisChannelManager.php
@@ -500,7 +500,7 @@ class RedisChannelManager extends LocalChannelManager
         }
 
         if ($config['database']) {
-            $query['database'] = $config['database'];
+            $query['db'] = $config['database'];
         }
 
         $query = http_build_query($query);


### PR DESCRIPTION
Key ".modes" was missing, always making it default