### PR TITLE
[fix] Check for key app on authorization

### DIFF
--- a/src/Statistics/Http/Middleware/Authorize.php
+++ b/src/Statistics/Http/Middleware/Authorize.php
@@ -8,6 +8,10 @@ class Authorize
 {
     public function handle($request, $next)
     {
-        return is_null(App::findBySecret($request->secret)) ? abort(403) : $next($request);
+        $app = App::findByKey($request->key);
+
+        return is_null($app) || $app->secret !== $request->secret
+            ? abort(403)
+            : $next($request);
     }
 }

--- a/tests/Statistics/Controllers/WebSocketsStatisticsControllerTest.php
+++ b/tests/Statistics/Controllers/WebSocketsStatisticsControllerTest.php
@@ -14,6 +14,7 @@ class WebSocketsStatisticsControllerTest extends TestCase
         $this->post(
             action([WebSocketStatisticsEntriesController::class, 'store']),
             array_merge($this->payload(), [
+                'key' => config('websockets.apps.0.key'),
                 'secret' => config('websockets.apps.0.secret'),
             ])
         );


### PR DESCRIPTION
It does better by searching for a key instead of a secret.

Closes #622 