### PR TITLE
[fix] Fix stale data

### DIFF
--- a/src/Contracts/StatisticsCollector.php
+++ b/src/Contracts/StatisticsCollector.php
@@ -66,4 +66,13 @@ interface StatisticsCollector
      * @return PromiseInterface[\BeyondCode\LaravelWebSockets\Statistics\Statistic|null]
      */
     public function getAppStatistics($appId): PromiseInterface;
+
+    /**
+     * Remove all app traces from the database if no connections have been set
+     * in the meanwhile since last save.
+     *
+     * @param  string|int  $appId
+     * @return void
+     */
+    public function resetAppTraces($appId);
 }

--- a/src/Statistics/Collectors/MemoryCollector.php
+++ b/src/Statistics/Collectors/MemoryCollector.php
@@ -92,6 +92,12 @@ class MemoryCollector implements StatisticsCollector
                     continue;
                 }
 
+                if ($statistic->shouldHaveTracesRemoved()) {
+                    $this->resetAppTraces($appId);
+
+                    continue;
+                }
+
                 $this->createRecord($statistic, $appId);
 
                 $this->channelManager->getGlobalConnectionsCount($appId)->then(function ($connections) use ($statistic) {
@@ -134,6 +140,18 @@ class MemoryCollector implements StatisticsCollector
         return Helpers::createFulfilledPromise(
             $this->statistics[$appId] ?? null
         );
+    }
+
+    /**
+     * Remove all app traces from the database if no connections have been set
+     * in the meanwhile since last save.
+     *
+     * @param  string|int  $appId
+     * @return void
+     */
+    public function resetAppTraces($appId)
+    {
+        unset($this->statistics[$appId]);
     }
 
     /**

--- a/src/Statistics/Collectors/RedisCollector.php
+++ b/src/Statistics/Collectors/RedisCollector.php
@@ -249,7 +249,7 @@ class RedisCollector extends MemoryCollector
 
         $this->channelManager->getPublishClient()->hset(
             $this->channelManager->getRedisKey($appId, null, ['stats']),
-            'peak_connections_count', $currentConnectionCount
+            'peak_connections_count', max(0, $currentConnectionCount)
         );
 
         $this->channelManager->getPublishClient()->hset(

--- a/src/Statistics/Collectors/RedisCollector.php
+++ b/src/Statistics/Collectors/RedisCollector.php
@@ -161,6 +161,10 @@ class RedisCollector extends MemoryCollector
                                 $appId, Helpers::redisListToArray($list)
                             );
 
+                            if ($statistic->shouldHaveTracesRemoved()) {
+                                return $this->resetAppTraces($appId);
+                            }
+
                             $this->createRecord($statistic, $appId);
 
                             $this->channelManager
@@ -272,6 +276,8 @@ class RedisCollector extends MemoryCollector
      */
     public function resetAppTraces($appId)
     {
+        parent::resetAppTraces($appId);
+
         $this->channelManager->getPublishClient()->hdel(
             $this->channelManager->getRedisKey($appId, null, ['stats']),
             'current_connections_count'

--- a/src/Statistics/Statistic.php
+++ b/src/Statistics/Statistic.php
@@ -184,6 +184,18 @@ class Statistic
     }
 
     /**
+     * Check if the current statistic entry is empty. This means
+     * that the statistic entry can be easily deleted if no activity
+     * occured for a while.
+     *
+     * @return bool
+     */
+    public function shouldHaveTracesRemoved(): bool
+    {
+        return $this->currentConnectionsCount === 0 && $this->peakConnectionsCount === 0;
+    }
+
+    /**
      * Transform the statistic to array.
      *
      * @return array

--- a/src/Statistics/Statistic.php
+++ b/src/Statistics/Statistic.php
@@ -178,7 +178,7 @@ class Statistic
     public function reset(int $currentConnectionsCount)
     {
         $this->currentConnectionsCount = $currentConnectionsCount;
-        $this->peakConnectionsCount = $currentConnectionsCount;
+        $this->peakConnectionsCount = max(0, $currentConnectionsCount);
         $this->webSocketMessagesCount = 0;
         $this->apiMessagesCount = 0;
     }

--- a/tests/PresenceChannelTest.php
+++ b/tests/PresenceChannelTest.php
@@ -117,6 +117,18 @@ class PresenceChannelTest extends TestCase
         $this->channelManager->getChannelMembers('1234', 'presence-channel')->then(function ($members) {
             $this->assertCount(2, $members);
         });
+
+        $this->pusherServer->onClose($rick);
+        $this->pusherServer->onClose($morty);
+        $this->pusherServer->onClose($pickleRick);
+
+        $this->channelManager->getGlobalConnectionsCount('1234', 'presence-channel')->then(function ($total) {
+            $this->assertEquals(3, $total);
+        });
+
+        $this->channelManager->getChannelMembers('1234', 'presence-channel')->then(function ($members) {
+            $this->assertCount(2, $members);
+        });
     }
 
     public function test_presence_channel_broadcast_member_events()

--- a/tests/PresenceChannelTest.php
+++ b/tests/PresenceChannelTest.php
@@ -117,18 +117,6 @@ class PresenceChannelTest extends TestCase
         $this->channelManager->getChannelMembers('1234', 'presence-channel')->then(function ($members) {
             $this->assertCount(2, $members);
         });
-
-        $this->pusherServer->onClose($rick);
-        $this->pusherServer->onClose($morty);
-        $this->pusherServer->onClose($pickleRick);
-
-        $this->channelManager->getGlobalConnectionsCount('1234', 'presence-channel')->then(function ($total) {
-            $this->assertEquals(3, $total);
-        });
-
-        $this->channelManager->getChannelMembers('1234', 'presence-channel')->then(function ($members) {
-            $this->assertCount(2, $members);
-        });
     }
 
     public function test_presence_channel_broadcast_member_events()

--- a/tests/StatisticsStoreTest.php
+++ b/tests/StatisticsStoreTest.php
@@ -16,6 +16,23 @@ class StatisticsStoreTest extends TestCase
         $this->assertEquals('2', $records[0]['peak_connections_count']);
         $this->assertEquals('2', $records[0]['websocket_messages_count']);
         $this->assertEquals('0', $records[0]['api_messages_count']);
+
+        $this->pusherServer->onClose($rick);
+        $this->pusherServer->onClose($morty);
+
+        $this->statisticsCollector->save();
+
+        $this->assertCount(2, $records = $this->statisticsStore->getRecords());
+
+        $this->assertEquals('2', $records[1]['peak_connections_count']);
+        $this->assertEquals('0', $records[1]['websocket_messages_count']);
+        $this->assertEquals('0', $records[1]['api_messages_count']);
+
+        $this->statisticsCollector->save();
+
+        // The last one should not generate any more records
+        // since the current state is empty.
+        $this->assertCount(2, $records = $this->statisticsStore->getRecords());
     }
 
     public function test_store_statistics_on_private_channel()
@@ -30,19 +47,55 @@ class StatisticsStoreTest extends TestCase
         $this->assertEquals('2', $records[0]['peak_connections_count']);
         $this->assertEquals('2', $records[0]['websocket_messages_count']);
         $this->assertEquals('0', $records[0]['api_messages_count']);
+
+        $this->pusherServer->onClose($rick);
+        $this->pusherServer->onClose($morty);
+
+        $this->statisticsCollector->save();
+
+        $this->assertCount(2, $records = $this->statisticsStore->getRecords());
+
+        $this->assertEquals('2', $records[1]['peak_connections_count']);
+        $this->assertEquals('0', $records[1]['websocket_messages_count']);
+        $this->assertEquals('0', $records[1]['api_messages_count']);
+
+        $this->statisticsCollector->save();
+
+        // The last one should not generate any more records
+        // since the current state is empty.
+        $this->assertCount(2, $records = $this->statisticsStore->getRecords());
     }
 
     public function test_store_statistics_on_presence_channel()
     {
         $rick = $this->newPresenceConnection('presence-channel', ['user_id' => 1]);
         $morty = $this->newPresenceConnection('presence-channel', ['user_id' => 2]);
+        $pickleRick = $this->newPresenceConnection('presence-channel', ['user_id' => 1]);
 
         $this->statisticsCollector->save();
 
         $this->assertCount(1, $records = $this->statisticsStore->getRecords());
 
-        $this->assertEquals('2', $records[0]['peak_connections_count']);
-        $this->assertEquals('2', $records[0]['websocket_messages_count']);
+        $this->assertEquals('3', $records[0]['peak_connections_count']);
+        $this->assertEquals('3', $records[0]['websocket_messages_count']);
         $this->assertEquals('0', $records[0]['api_messages_count']);
+
+        $this->pusherServer->onClose($rick);
+        $this->pusherServer->onClose($morty);
+        $this->pusherServer->onClose($pickleRick);
+
+        $this->statisticsCollector->save();
+
+        $this->assertCount(2, $records = $this->statisticsStore->getRecords());
+
+        $this->assertEquals('3', $records[1]['peak_connections_count']);
+        $this->assertEquals('0', $records[1]['websocket_messages_count']);
+        $this->assertEquals('0', $records[1]['api_messages_count']);
+
+        $this->statisticsCollector->save();
+
+        // The last one should not generate any more records
+        // since the current state is empty.
+        $this->assertCount(2, $records = $this->statisticsStore->getRecords());
     }
 }

--- a/tests/StatisticsStoreTest.php
+++ b/tests/StatisticsStoreTest.php
@@ -25,8 +25,6 @@ class StatisticsStoreTest extends TestCase
         $this->assertCount(2, $records = $this->statisticsStore->getRecords());
 
         $this->assertEquals('2', $records[1]['peak_connections_count']);
-        $this->assertEquals('0', $records[1]['websocket_messages_count']);
-        $this->assertEquals('0', $records[1]['api_messages_count']);
 
         $this->statisticsCollector->save();
 
@@ -56,8 +54,6 @@ class StatisticsStoreTest extends TestCase
         $this->assertCount(2, $records = $this->statisticsStore->getRecords());
 
         $this->assertEquals('2', $records[1]['peak_connections_count']);
-        $this->assertEquals('0', $records[1]['websocket_messages_count']);
-        $this->assertEquals('0', $records[1]['api_messages_count']);
 
         $this->statisticsCollector->save();
 
@@ -89,8 +85,6 @@ class StatisticsStoreTest extends TestCase
         $this->assertCount(2, $records = $this->statisticsStore->getRecords());
 
         $this->assertEquals('3', $records[1]['peak_connections_count']);
-        $this->assertEquals('0', $records[1]['websocket_messages_count']);
-        $this->assertEquals('0', $records[1]['api_messages_count']);
 
         $this->statisticsCollector->save();
 


### PR DESCRIPTION
This PR will be addressed to any stale data that was previously found on production environments, as well as the ones related to stale data still present in Redis, like https://github.com/beyondcode/laravel-websockets/issues/508#issuecomment-713548902

### Trace resetting
Trace resetting is a way of saying "do not store an array key in-memory/in-database for this app because no activity was recently found". Trace resetting will take care to stop making data points if there was no activity, instead of making data points with 0 values.

### Stale data
Stale data is being present because of the hard shutdowns of the app. If there are any connections that get hard deleted without being able to close all the connections in a soft manner, we can end up with stored members into Redis, but without active connections existent.

Also:
- Fixed a bug where peak connections were staling to a specific value, creating infinite data points (https://github.com/beyondcode/laravel-websockets/pull/633/commits/8d1369ee0248879196cfb81d29c8441ffa9aaf7b)
