### PR TITLE
Update rename_statistics_counters migration for sqlite compatability

### DIFF
--- a/database/migrations/0000_00_00_000000_rename_statistics_counters.php
+++ b/database/migrations/0000_00_00_000000_rename_statistics_counters.php
@@ -15,11 +15,14 @@ class RenameStatisticsCounters extends Migration
     {
         Schema::table('websockets_statistics_entries', function (Blueprint $table) {
             $table->renameColumn('peak_connection_count', 'peak_connections_count');
+        });
+        Schema::table('websockets_statistics_entries', function (Blueprint $table) {
             $table->renameColumn('websocket_message_count', 'websocket_messages_count');
+        });
+        Schema::table('websockets_statistics_entries', function (Blueprint $table) {
             $table->renameColumn('api_message_count', 'api_messages_count');
         });
     }
-
     /**
      * Reverse the migrations.
      *
@@ -29,7 +32,11 @@ class RenameStatisticsCounters extends Migration
     {
         Schema::table('websockets_statistics_entries', function (Blueprint $table) {
             $table->renameColumn('peak_connections_count', 'peak_connection_count');
+        });
+        Schema::table('websockets_statistics_entries', function (Blueprint $table) {
             $table->renameColumn('websocket_messages_count', 'websocket_message_count');
+        });
+        Schema::table('websockets_statistics_entries', function (Blueprint $table) {
             $table->renameColumn('api_messages_count', 'api_message_count');
         });
     }


### PR DESCRIPTION
Separate the `renameColumn` calls makes the migration sqlite compatible. No downsides