### PR TITLE
[2.x] Customize dashboard domain and path using env vars

### DIFF
--- a/config/websockets.php
+++ b/config/websockets.php
@@ -73,7 +73,7 @@ return [
             'enable_client_messages' => false,
             'enable_statistics' => true,
             'allowed_origins' => [
-                // env('LARAVEL_WEBSOCKETS_DOMAIN')
+                // env('LARAVEL_WEBSOCKETS_DOMAIN'),
             ],
         ],
     ],

--- a/config/websockets.php
+++ b/config/websockets.php
@@ -15,7 +15,9 @@ return [
 
         'port' => env('LARAVEL_WEBSOCKETS_PORT', 6001),
 
-        'path' => 'laravel-websockets',
+        'domain' => env('LARAVEL_WEBSOCKETS_DOMAIN'),
+
+        'path' => env('LARAVEL_WEBSOCKETS_PATH', 'laravel-websockets'),
 
         'middleware' => [
             'web',
@@ -71,7 +73,7 @@ return [
             'enable_client_messages' => false,
             'enable_statistics' => true,
             'allowed_origins' => [
-                //
+                // env('LARAVEL_WEBSOCKETS_DOMAIN')
             ],
         ],
     ],

--- a/src/WebSocketsServiceProvider.php
+++ b/src/WebSocketsServiceProvider.php
@@ -155,6 +155,7 @@ class WebSocketsServiceProvider extends ServiceProvider
     protected function registerDashboardRoutes()
     {
         Route::group([
+            'domain' => config('websockets.dashboard.domain'),
             'prefix' => config('websockets.dashboard.path'),
             'as' => 'laravel-websockets.',
             'middleware' => config('websockets.dashboard.middleware', [AuthorizeDashboard::class]),


### PR DESCRIPTION
This PR adds an option to customize dashboard domain and path (prefix) using environment variables, similar to Telescope or Horizon.