### PR TITLE
Support and test PHP 8.0

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest, windows-latest]
-                php: [7.4, 7.3, 7.2]
+                php: [8.0, 7.4, 7.3, 7.2]
                 laravel: [6.*, 7.*, 8.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 include:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -39,7 +39,7 @@ jobs:
                 uses: shivammathur/setup-php@v2
                 with:
                     php-version: ${{ matrix.php }}
-                    extensions: curl, dom, libxml, mbstring, pdo, sqlite, pdo_sqlite, zip
+                    extensions: curl, dom, fileinfo, libxml, mbstring, pdo, sqlite, pdo_sqlite, zip
                     coverage: pcov
 
             -   name: Install dependencies

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2|^8.0",
         "ext-json": "*",
         "cboden/ratchet": "^0.4.1",
         "facade/ignition-contracts": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "symfony/psr-http-message-bridge": "^1.1|^2.0"
     },
     "require-dev": {
-        "mockery/mockery": "^1.3",
+        "mockery/mockery": "^1.3.3",
         "orchestra/testbench": "^4.0|^5.0|^6.0",
         "phpunit/phpunit": "^8.0|^9.0"
     },


### PR DESCRIPTION
I would like to at least test and see if PHP 8.0 would work with the existing codebase.

This is for the issue #639 about PHP 8.0. It is mentioned there that 2.x will have PHP 8.0 support, but it's only in beta and has been so for at least 5 months. Also having to upgrade to it means having to deal with potentially breaking changes which don't even seem to be listed anywhere, assuming there are breaking changes.

Also there was a PR for PHP 8.0 support for version 1.x (#659), but unlike there, here I make the change to the CI config as well to test in PHP 8.0.