### PR TITLE
fix never releasing lock

### DIFF
--- a/src/ChannelManagers/LocalChannelManager.php
+++ b/src/ChannelManagers/LocalChannelManager.php
@@ -451,7 +451,7 @@ class LocalChannelManager implements ChannelManager
         });
 
         return Helpers::createFulfilledPromise(
-            $this->lock()->release()
+            $this->lock()->forceRelease()
         );
     }
 


### PR DESCRIPTION
hi,

while debugging the stale connections issue i found this bug:

https://github.com/beyondcode/laravel-websockets/blob/11630783282eb0a189ea4ff902574b3d195f2ac9/src/ChannelManagers/LocalChannelManager.php#L454

is never successfull as 

https://github.com/beyondcode/laravel-websockets/blob/11630783282eb0a189ea4ff902574b3d195f2ac9/src/ChannelManagers/LocalChannelManager.php#L537

always returns a _new_ random owner and `release` won't allow this, so line 454 needs the fix