### PR TITLE
[1.x] Add support for php-pusher 5.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "illuminate/http": "^6.0|^7.0|^8.0",
         "illuminate/routing": "^6.0|^7.0|^8.0",
         "illuminate/support": "^6.0|^7.0|^8.0",
-        "pusher/pusher-php-server": "^3.0|^4.0",
+        "pusher/pusher-php-server": "^3.0|^4.0|^5.0",
         "react/dns": "^1.1",
         "react/http": "^1.1",
         "symfony/http-kernel": "^4.0|^5.0",

--- a/src/HttpApi/Controllers/TriggerEventController.php
+++ b/src/HttpApi/Controllers/TriggerEventController.php
@@ -31,6 +31,6 @@ class TriggerEventController extends Controller
             StatisticsLogger::apiMessage($request->appId);
         }
 
-        return $request->json()->all();
+        return (object) [];
     }
 }


### PR DESCRIPTION
This package is almost compatible with php-pusher 5.x out of the box.

5.x expects a empty repsonse, or a response containing channel information (Expirimental) (See pusher docs: https://pusher.com/docs/channels/library_auth_reference/rest-api#successful-response)

This change looks to be backwards compatible with 4.x since the old php-pusher package didn't do anything with the responded data.