### PR TITLE
fix unsubscribeFromAllChannels / stale connections

### DIFF
--- a/src/ChannelManagers/LocalChannelManager.php
+++ b/src/ChannelManagers/LocalChannelManager.php
@@ -173,7 +173,10 @@ class LocalChannelManager implements ChannelManager
 
         $this->getLocalChannels($connection->app->id)
             ->then(function ($channels) use ($connection) {
-                collect($channels)->each->unsubscribe($connection);
+                collect($channels)
+                	->each(function (Channel $channel) use ($connection) {
+                		$channel->unsubscribe($connection);
+                	});
 
                 collect($channels)
                     ->reject->hasConnections()


### PR DESCRIPTION
the `each->` call silently ran only for the first channel leading to
users on other channels seeming randomly not getting unsubscribed,
stale connections, a frustrated dev and a fishy smell all over the place.

after some serious hours of debugging and searching for this sneaky bug
the websocket-world is now a better place ;)

please merge ASAP, this is relevant for basically all setups that use more than one channel!
should fix e.g. #654, #657, #623 and propably #228, 