### PR TITLE
[2.x] Fix Websocket Handlers registration

### DIFF
--- a/docs/advanced-usage/custom-websocket-handlers.md
+++ b/docs/advanced-usage/custom-websocket-handlers.md
@@ -53,7 +53,7 @@ This class takes care of registering the routes with the actual webSocket server
 This could, for example, be done inside your `routes/web.php` file.
 
 ```php
-WebSocketsRouter::get('/my-websocket', \App\MyCustomWebSocketHandler::class);
+WebSocketsRouter::addCustomRoute('GET', '/my-websocket', \App\MyCustomWebSocketHandler::class);
 ```
 
 Once you've added the custom WebSocket route, be sure to restart our WebSocket server for the changes to take place.

--- a/src/Console/Commands/StartServer.php
+++ b/src/Console/Commands/StartServer.php
@@ -158,7 +158,7 @@ class StartServer extends Command
      */
     protected function configureRoutes()
     {
-        WebSocketRouter::routes();
+        WebSocketRouter::registerRoutes();
     }
 
     /**

--- a/tests/Handlers/TestHandler.php
+++ b/tests/Handlers/TestHandler.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace BeyondCode\LaravelWebSockets\Test\Handlers;
+
+use Exception;
+use Ratchet\ConnectionInterface;
+use Ratchet\RFC6455\Messaging\MessageInterface;
+use Ratchet\WebSocket\MessageComponentInterface;
+
+class TestHandler implements MessageComponentInterface
+{
+    public function onOpen(ConnectionInterface $connection)
+    {
+        $connection->close();
+    }
+
+    public function onClose(ConnectionInterface $connection)
+    {
+        //
+    }
+
+    public function onError(ConnectionInterface $connection, Exception $e)
+    {
+        dump($e->getMessage());
+    }
+
+    public function onMessage(ConnectionInterface $connection, MessageInterface $msg)
+    {
+        dump($msg);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,6 +5,7 @@ namespace BeyondCode\LaravelWebSockets\Test;
 use BeyondCode\LaravelWebSockets\Contracts\ChannelManager;
 use BeyondCode\LaravelWebSockets\Contracts\StatisticsCollector;
 use BeyondCode\LaravelWebSockets\Contracts\StatisticsStore;
+use BeyondCode\LaravelWebSockets\Facades\WebSocketRouter;
 use BeyondCode\LaravelWebSockets\Helpers;
 use GuzzleHttp\Psr7\Request;
 use Illuminate\Support\Facades\Redis;
@@ -77,6 +78,8 @@ abstract class TestCase extends Orchestra
         $this->loadLaravelMigrations(['--database' => 'sqlite']);
         $this->loadMigrationsFrom(__DIR__.'/database/migrations');
         $this->withFactories(__DIR__.'/database/factories');
+
+        $this->registerCustomPath();
 
         $this->registerPromiseResolver();
 
@@ -216,6 +219,20 @@ abstract class TestCase extends Orchestra
                 'collector' => \BeyondCode\LaravelWebSockets\Statistics\Collectors\RedisCollector::class,
             ],
         ]);
+    }
+
+    /**
+     * Register custom paths.
+     *
+     * @return void
+     */
+    protected function registerCustomPath()
+    {
+        WebSocketRouter::addCustomRoute('GET', '/test', Handlers\TestHandler::class);
+        WebSocketRouter::addCustomRoute('POST', '/test', Handlers\TestHandler::class);
+        WebSocketRouter::addCustomRoute('PUT', '/test', Handlers\TestHandler::class);
+        WebSocketRouter::addCustomRoute('PATCH', '/test', Handlers\TestHandler::class);
+        WebSocketRouter::addCustomRoute('DELETE', '/test', Handlers\TestHandler::class);
     }
 
     /**


### PR DESCRIPTION
Closes #731 #660

Registering custom websocket handlers can now be done like this:

```php
WebSocketsRouter::addCustomRoute('GET', '/my-websocket', \App\MyCustomWebSocketHandler::class);
```