### PR TITLE
[2.x] Seems like typo in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "facade/ignition-contracts": "^1.0",
         "guzzlehttp/psr7": "^1.5",
         "illuminate/broadcasting": "^6.3|^7.0|^8.0",
-        "illuminate/console": "^6.3|7.0|^8.0",
+        "illuminate/console": "^6.3|^7.0|^8.0",
         "illuminate/http": "^6.3|^7.0|^8.0",
         "illuminate/queue": "^6.3|^7.0|^8.0",
         "illuminate/routing": "^6.3|^7.0|^8.0",


### PR DESCRIPTION
Looks like you missed ^ symbol in illuminate/console dependancy