### PR TITLE
increased redis lock seconds to 2 minutes

### DIFF
--- a/config/websockets.php
+++ b/config/websockets.php
@@ -166,6 +166,8 @@ return [
 
                 'collector' => \BeyondCode\LaravelWebSockets\Statistics\Collectors\RedisCollector::class,
 
+                'lock_timeout' => 60 * 2,
+
             ],
 
         ],

--- a/src/ChannelManagers/RedisChannelManager.php
+++ b/src/ChannelManagers/RedisChannelManager.php
@@ -809,7 +809,7 @@ class RedisChannelManager extends LocalChannelManager
      */
     protected function lock()
     {
-        return new RedisLock($this->redis, static::$lockName, 60 * 2);
+        return new RedisLock($this->redis, static::$lockName, config('websockets.replication.modes.redis.lock_timeout', 60 * 2));
     }
 
     /**

--- a/src/ChannelManagers/RedisChannelManager.php
+++ b/src/ChannelManagers/RedisChannelManager.php
@@ -809,7 +809,7 @@ class RedisChannelManager extends LocalChannelManager
      */
     protected function lock()
     {
-        return new RedisLock($this->redis, static::$lockName, 0);
+        return new RedisLock($this->redis, static::$lockName, 60 * 2);
     }
 
     /**

--- a/src/Statistics/Collectors/RedisCollector.php
+++ b/src/Statistics/Collectors/RedisCollector.php
@@ -353,7 +353,7 @@ class RedisCollector extends MemoryCollector
      */
     protected function lock()
     {
-        return new RedisLock($this->redis, static::$redisLockName, 0);
+        return new RedisLock($this->redis, static::$redisLockName, config('websockets.replication.modes.redis.lock_timeout', 60 * 2));
     }
 
     /**


### PR DESCRIPTION
This pull request should solve this issue: https://github.com/beyondcode/laravel-websockets/issues/724

Please checkout the issue for descriptions.

If any one previously encountered same issue before this fix, then they will have to clear their `redis` database or manually delete the `lock key` in order for this fix to take effect.