### PR TITLE
Fixes project stability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,7 @@
     "config": {
         "sort-packages": true
     },
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "extra": {
         "laravel": {
             "providers": [


### PR DESCRIPTION
For some reason, as written here, composer requires on-development non-stable packages. This line fixes it.