### PR TITLE
Remove `orchestra/database`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,6 @@
         "clue/block-react": "^1.4",
         "laravel/legacy-factories": "^1.1",
         "orchestra/testbench-browser-kit": "^4.0|^5.0|^6.0",
-        "orchestra/database": "^4.0|^5.0|^6.0",
         "phpunit/phpunit": "^8.0|^9.0"
     },
     "suggest": {


### PR DESCRIPTION
This dependency isn't required since Testbench 3.6