### PR TITLE
[1.x] Add basic implementation of subprotocols

### DIFF
--- a/src/Server/Logger/HttpLogger.php
+++ b/src/Server/Logger/HttpLogger.php
@@ -5,8 +5,9 @@ namespace BeyondCode\LaravelWebSockets\Server\Logger;
 use Exception;
 use Ratchet\ConnectionInterface;
 use Ratchet\MessageComponentInterface;
+use Ratchet\WebSocket\WsServerInterface;
 
-class HttpLogger extends Logger implements MessageComponentInterface
+class HttpLogger extends Logger implements MessageComponentInterface, WsServerInterface
 {
     /** @var \Ratchet\Http\HttpServerInterface */
     protected $app;
@@ -23,6 +24,15 @@ class HttpLogger extends Logger implements MessageComponentInterface
         $this->app = $app;
 
         return $this;
+    }
+
+    public function getSubProtocols()
+    {
+        if ($this->app instanceof WsServerInterface) {
+            return $this->app->getSubProtocols();
+        } else {
+            return [];
+        }
     }
 
     public function onOpen(ConnectionInterface $connection)

--- a/src/Server/Logger/WebsocketsLogger.php
+++ b/src/Server/Logger/WebsocketsLogger.php
@@ -7,8 +7,9 @@ use Exception;
 use Ratchet\ConnectionInterface;
 use Ratchet\RFC6455\Messaging\MessageInterface;
 use Ratchet\WebSocket\MessageComponentInterface;
+use Ratchet\WebSocket\WsServerInterface;
 
-class WebsocketsLogger extends Logger implements MessageComponentInterface
+class WebsocketsLogger extends Logger implements MessageComponentInterface, WsServerInterface
 {
     /** @var \Ratchet\Http\HttpServerInterface */
     protected $app;
@@ -25,6 +26,15 @@ class WebsocketsLogger extends Logger implements MessageComponentInterface
         $this->app = $app;
 
         return $this;
+    }
+
+    public function getSubProtocols()
+    {
+        if ($this->app instanceof WsServerInterface) {
+            return $this->app->getSubProtocols();
+        } else {
+            return [];
+        }
     }
 
     public function onOpen(ConnectionInterface $connection)

--- a/src/WebSockets/WebSocketHandler.php
+++ b/src/WebSockets/WebSocketHandler.php
@@ -15,8 +15,9 @@ use Exception;
 use Ratchet\ConnectionInterface;
 use Ratchet\RFC6455\Messaging\MessageInterface;
 use Ratchet\WebSocket\MessageComponentInterface;
+use Ratchet\WebSocket\WsServerInterface;
 
-class WebSocketHandler implements MessageComponentInterface
+class WebSocketHandler implements MessageComponentInterface, WsServerInterface
 {
     /** @var \BeyondCode\LaravelWebSockets\WebSockets\Channels\ChannelManager */
     protected $channelManager;
@@ -24,6 +25,20 @@ class WebSocketHandler implements MessageComponentInterface
     public function __construct(ChannelManager $channelManager)
     {
         $this->channelManager = $channelManager;
+    }
+
+    /*
+     * Match pusher channel protocols
+     * @link https://pusher.com/docs/channels/library_auth_reference/pusher-websockets-protocol
+     */
+    public function getSubProtocols()
+    {
+        return [
+            'pusher-channels-protocol-7',
+            'pusher-channels-protocol-6',
+            'pusher-channels-protocol-5',
+            'pusher-channels-protocol-4',
+        ];
     }
 
     public function onOpen(ConnectionInterface $connection)


### PR DESCRIPTION
Fixes #602.

The latest Pusher SDKs send a `Sec-WebSocket-Protocol` header when connecting to the server, causing Ratchet to check available sub-protocols. If it doesn't find any that match, it bails out with an error 426 "No Sec-WebSocket-Protocols requested supported".

For more info on my findings are available in the original issue #602.

Regarding the implementation, I had to add the `WsServerInterface` to both loggers, as they decorate the actual websocket handler, and thus need to provide the same information.