### PR TITLE
Message not propagated across servers when using pusher-http-server trigger on another client without subscribing

### DIFF
--- a/src/ChannelManagers/RedisChannelManager.php
+++ b/src/ChannelManagers/RedisChannelManager.php
@@ -619,6 +619,10 @@ class RedisChannelManager extends LocalChannelManager
 
     /**
      * Check if channel is on the list.
+     *
+     * @param  string|int  $appId
+     * @param  string  $channel
+     * @return PromiseInterface
      */
     public function isChannelInSet($appId, string $channel): PromiseInterface
     {

--- a/src/ChannelManagers/RedisChannelManager.php
+++ b/src/ChannelManagers/RedisChannelManager.php
@@ -431,7 +431,13 @@ class RedisChannelManager extends LocalChannelManager
 
     public function find($appId, string $channel)
     {
-        return $this->findOrCreate($appId, $channel);
+        if (! $channelInstance = parent::find($appId, $channel)) {
+            $class = $this->getChannelClassName($channel);
+
+            $this->channels[$appId][$channel] = new $class($channel);
+        }
+
+        return $this->channels[$appId][$channel];
     }
 
     /**

--- a/src/ChannelManagers/RedisChannelManager.php
+++ b/src/ChannelManagers/RedisChannelManager.php
@@ -437,6 +437,8 @@ class RedisChannelManager extends LocalChannelManager
                     $class = $this->getChannelClassName($channel);
                     $this->channels[$appId][$channel] = new $class($channel);
                 }
+            }else{
+                unset($this->channels[$appId][$channel]);
             }
         });
 

--- a/src/ChannelManagers/RedisChannelManager.php
+++ b/src/ChannelManagers/RedisChannelManager.php
@@ -429,6 +429,11 @@ class RedisChannelManager extends LocalChannelManager
         $channel->broadcastLocallyToEveryoneExcept($payload, $socketId, $appId);
     }
 
+    public function find($appId, string $channel)
+    {
+        return $this->findOrCreate($appId, $channel);
+    }
+
     /**
      * Build the Redis connection URL from Laravel database config.
      *

--- a/src/ChannelManagers/RedisChannelManager.php
+++ b/src/ChannelManagers/RedisChannelManager.php
@@ -431,17 +431,16 @@ class RedisChannelManager extends LocalChannelManager
 
     public function find($appId, string $channel)
     {
-        return $this->isChannelInSet($appId, $channel)->then(function($isInSet) use($appId, $channel){
+        $this->isChannelInSet($appId, $channel)->then(function($isInSet) use($appId, $channel){
             if($isInSet){
                 if (! $channelInstance = parent::find($appId, $channel)) {
                     $class = $this->getChannelClassName($channel);
-
                     $this->channels[$appId][$channel] = new $class($channel);
                 }
-                return $this->channels[$appId][$channel];
             }
-            return null;
         });
+
+        return parent::find($appId, $channel);
     }
 
     /**


### PR DESCRIPTION
End-users subscribe to channel on server1 and backend trigger event on server2. When that happens, channel is not defined locally on server2 and in effect will not propagate across servers the message received on server2.

PusherClientMessage respond method only broadcasts to everyone if channel is found. This code change ensures that when a message is received on server2 and channel is registered on the redis channel set, it is created on the server so the channel can broadcast across other servers.