### PR TITLE
Fix missing `wssPort` for SSL example

### DIFF
--- a/docs/basic-usage/ssl.md
+++ b/docs/basic-usage/ssl.md
@@ -61,6 +61,7 @@ window.Echo = new Echo({
     key: 'your-pusher-key',
     wsHost: window.location.hostname,
     wsPort: 6001,
+    wssPort: 6001,
     disableStats: true,
     forceTLS: true
 });


### PR DESCRIPTION
Not sure which doc branch is deployed currently but this should also be merged to master probably.

Could save some hours of debugging if you don't notice the missing port in the failed websocket connection URL.