### PR TITLE
guzzlehttp/psr7  2.0 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "doctrine/dbal": "^2.9",
         "evenement/evenement": "^2.0|^3.0",
         "facade/ignition-contracts": "^1.0",
-        "guzzlehttp/psr7": "^1.5",
+        "guzzlehttp/psr7": "^1.5|^2.0",
         "illuminate/broadcasting": "^6.3|^7.0|^8.0",
         "illuminate/console": "^6.3|^7.0|^8.0",
         "illuminate/http": "^6.3|^7.0|^8.0",


### PR DESCRIPTION
` Problem 1
    - beyondcode/laravel-websockets[1.12.0, ..., 1.x-dev] require guzzlehttp/psr7 ^1.5 -> found guzzlehttp/psr7[1.5.0, ..., 1.x-dev] but the package is fixed to 2.0.0 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
    - Root composer.json requires beyondcode/laravel-websockets ^1.12 -> satisfiable by beyondcode/laravel-websockets[1.12.0, 1.x-dev].

Use the option --with-all-dependencies (-W) to allow upgrades, downgrades and removals for packages currently locked to specific versions.`