### PR TITLE
Listen for react server errors

### DIFF
--- a/src/Console/StartWebSocketServer.php
+++ b/src/Console/StartWebSocketServer.php
@@ -6,6 +6,7 @@ use BeyondCode\LaravelWebSockets\Facades\StatisticsLogger;
 use BeyondCode\LaravelWebSockets\Facades\WebSocketsRouter;
 use BeyondCode\LaravelWebSockets\Server\Logger\ConnectionLogger;
 use BeyondCode\LaravelWebSockets\Server\Logger\HttpLogger;
+use BeyondCode\LaravelWebSockets\Server\Logger\ServerLogger;
 use BeyondCode\LaravelWebSockets\Server\Logger\WebsocketsLogger;
 use BeyondCode\LaravelWebSockets\Server\WebSocketServerFactory;
 use BeyondCode\LaravelWebSockets\Statistics\DnsResolver;
@@ -46,6 +47,7 @@ class StartWebSocketServer extends Command
             ->configureHttpLogger()
             ->configureMessageLogger()
             ->configureConnectionLogger()
+            ->configureServerLogger()
             ->configureRestartTimer()
             ->registerEchoRoutes()
             ->registerCustomRoutes()
@@ -105,6 +107,17 @@ class StartWebSocketServer extends Command
         app()->bind(ConnectionLogger::class, function ($app) {
             return (new ConnectionLogger($this->output))
                 ->enable($app['config']['app']['debug'] ?? false)
+                ->verbose($this->output->isVerbose());
+        });
+
+        return $this;
+    }
+
+    protected function configureServerLogger(): self
+    {
+        app()->singleton(ServerLogger::class, function ($app) {
+            return (new ServerLogger($this->output))
+                ->enable($this->option('debug') ?: ($app['config']['app']['debug'] ?? false))
                 ->verbose($this->output->isVerbose());
         });
 

--- a/src/Server/Logger/ServerLogger.php
+++ b/src/Server/Logger/ServerLogger.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace BeyondCode\LaravelWebSockets\Server\Logger;
+
+use Exception;
+use React\Socket\ServerInterface;
+
+class ServerLogger extends Logger
+{
+    public static function registerListeners(ServerInterface $server): void
+    {
+        /** @var ServerLogger $logger */
+        $logger = app(self::class);
+
+        $server->on('error', function (Exception $e) use ($logger) {
+            $logger->error($e->getMessage());
+        });
+    }
+}

--- a/src/Server/Logger/ServerLogger.php
+++ b/src/Server/Logger/ServerLogger.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 
 namespace BeyondCode\LaravelWebSockets\Server\Logger;
 


### PR DESCRIPTION
There's a barrage of SSL related issues in this repository, and as others have alluded to it's quite hard to understand where the problem is.

React emits an error when there's a problem with an incoming connection:
> Note that the certificate file will not be loaded on instantiation but when an incoming connection initializes its TLS context. This implies that any invalid certificate file paths or contents will only cause an error event at a later time.
https://github.com/reactphp/socket#secureserver

At the moment Ratchet only listens for the `connection` event - https://github.com/ratchetphp/Ratchet/blob/78fb27b015035147735f4f6a784d6b0cdc86c3e7/src/Ratchet/Server/IoServer.php#L48. `beyondcode/laravel-websockets` does not listen on any server events.

This PR adds a server `error` event listener, which will show output when the `--debug` option is used. For example, if `local_cert` is set to a file which doesn't exist or a file which the current user cannot read:
```console
$ sudo -u apache -H php artisan websockets:serve --debug -vvv
Starting the WebSocket server on port 6001...
Connection from tcp://127.0.0.1:46452 failed during TLS handshake: Unable to complete TLS handshake: SSL_R_NO_SHARED_CIPHER: no suitable shared cipher could be used.  This could be because the server is missing an SSL certificate (local_cert context option)

```

Given v2 is beta I am targeting this for v1 as I believe it will benefit more users, including myself. I will submit another PR for v2 as the code has changed significantly on that branch.