### PR TITLE
add configuration variable for active dashboard channels

### DIFF
--- a/config/websockets.php
+++ b/config/websockets.php
@@ -24,6 +24,29 @@ return [
             \BeyondCode\LaravelWebSockets\Dashboard\Http\Middleware\Authorize::class,
         ],
 
+        /*
+        |--------------------------------------------------------------------------
+        | Dashboard logger channels list
+        |--------------------------------------------------------------------------
+        |
+        | List of event channels which should be logged.
+        | In frequent ws event stream some log events like replication messages
+        | creates huge spam amount which is more disturbing than helpful.
+        | Removing channel from this list will prevent it being created in first place.
+        |
+        */
+
+        'channels' => [
+            \BeyondCode\LaravelWebSockets\DashboardLogger::TYPE_DISCONNECTED,
+            \BeyondCode\LaravelWebSockets\DashboardLogger::TYPE_CONNECTED,
+            \BeyondCode\LaravelWebSockets\DashboardLogger::TYPE_SUBSCRIBED,
+            \BeyondCode\LaravelWebSockets\DashboardLogger::TYPE_WS_MESSAGE,
+            \BeyondCode\LaravelWebSockets\DashboardLogger::TYPE_API_MESSAGE,
+            \BeyondCode\LaravelWebSockets\DashboardLogger::TYPE_REPLICATOR_SUBSCRIBED,
+            \BeyondCode\LaravelWebSockets\DashboardLogger::TYPE_REPLICATOR_UNSUBSCRIBED,
+            \BeyondCode\LaravelWebSockets\DashboardLogger::TYPE_REPLICATOR_MESSAGE_RECEIVED,
+        ],
+
     ],
 
     'managers' => [

--- a/src/DashboardLogger.php
+++ b/src/DashboardLogger.php
@@ -88,7 +88,7 @@ class DashboardLogger
     /**
      * Checks if channel needs to be logged.
      *
-     * @param  string $type
+     * @param  string  $type
      * @return bool
      */
     public static function isChannelEnabled(string $type): bool

--- a/src/DashboardLogger.php
+++ b/src/DashboardLogger.php
@@ -50,7 +50,7 @@ class DashboardLogger
      */
     public static function log($appId, string $type, array $details = [])
     {
-        if (!self::isChannelEnabled($type)) {
+        if (! self::isChannelEnabled($type)) {
             return null;
         }
 
@@ -86,9 +86,9 @@ class DashboardLogger
     }
 
     /**
-     * Checks if channel needs to be logged
+     * Checks if channel needs to be logged.
      *
-     * @param string $type
+     * @param  string $type
      * @return bool
      */
     public static function isChannelEnabled(string $type): bool

--- a/src/DashboardLogger.php
+++ b/src/DashboardLogger.php
@@ -50,6 +50,10 @@ class DashboardLogger
      */
     public static function log($appId, string $type, array $details = [])
     {
+        if (!self::isChannelEnabled($type)) {
+            return null;
+        }
+
         $channelManager = app(ChannelManager::class);
 
         $channelName = static::LOG_CHANNEL_PREFIX.$type;
@@ -79,5 +83,16 @@ class DashboardLogger
         $channelManager->broadcastAcrossServers(
             $appId, null, $channelName, (object) $payload
         );
+    }
+
+    /**
+     * Checks if channel needs to be logged
+     *
+     * @param string $type
+     * @return bool
+     */
+    public static function isChannelEnabled(string $type): bool
+    {
+        return in_array($type, config('websockets.dashboard.channels', self::$channels));
     }
 }


### PR DESCRIPTION
In frequent WS event stream some log events like replication messages creates huge spam amount in dashboard which is more disturbing than helpful.
Removing channel from this list will prevent it being created in first place.