### PR TITLE
Fix tests for Pusher V6 and V7

### DIFF
--- a/tests/FetchChannelTest.php
+++ b/tests/FetchChannelTest.php
@@ -5,7 +5,6 @@ namespace BeyondCode\LaravelWebSockets\Test;
 use BeyondCode\LaravelWebSockets\API\FetchChannel;
 use GuzzleHttp\Psr7\Request;
 use Illuminate\Http\JsonResponse;
-use Pusher\Pusher;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class FetchChannelTest extends TestCase
@@ -24,7 +23,7 @@ class FetchChannelTest extends TestCase
             'channelName' => 'my-channel',
         ];
 
-        $queryString = Pusher::build_auth_query_string(
+        $queryString = self::build_auth_query_string(
             'TestKey', 'InvalidSecret', 'GET', $requestPath
         );
 
@@ -48,7 +47,7 @@ class FetchChannelTest extends TestCase
             'channelName' => 'my-channel',
         ];
 
-        $queryString = Pusher::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath);
+        $queryString = self::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath);
 
         $request = new Request('GET', "{$requestPath}?{$queryString}&".http_build_query($routeParams));
 
@@ -79,7 +78,7 @@ class FetchChannelTest extends TestCase
             'channelName' => 'presence-channel',
         ];
 
-        $queryString = Pusher::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath);
+        $queryString = self::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath);
 
         $request = new Request('GET', "{$requestPath}?{$queryString}&".http_build_query($routeParams));
 
@@ -113,7 +112,7 @@ class FetchChannelTest extends TestCase
             'channelName' => 'invalid-channel',
         ];
 
-        $queryString = Pusher::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath);
+        $queryString = self::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath);
 
         $request = new Request('GET', "{$requestPath}?{$queryString}&".http_build_query($routeParams));
 

--- a/tests/FetchChannelsTest.php
+++ b/tests/FetchChannelsTest.php
@@ -5,7 +5,6 @@ namespace BeyondCode\LaravelWebSockets\Test;
 use BeyondCode\LaravelWebSockets\API\FetchChannels;
 use GuzzleHttp\Psr7\Request;
 use Illuminate\Http\JsonResponse;
-use Pusher\Pusher;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class FetchChannelsTest extends TestCase
@@ -23,7 +22,7 @@ class FetchChannelsTest extends TestCase
             'appId' => '1234',
         ];
 
-        $queryString = Pusher::build_auth_query_string(
+        $queryString = self::build_auth_query_string(
             'TestKey', 'InvalidSecret', 'GET', $requestPath
         );
 
@@ -46,7 +45,7 @@ class FetchChannelsTest extends TestCase
             'appId' => '1234',
         ];
 
-        $queryString = Pusher::build_auth_query_string(
+        $queryString = self::build_auth_query_string(
             'TestKey', 'TestSecret', 'GET', $requestPath
         );
 
@@ -81,7 +80,7 @@ class FetchChannelsTest extends TestCase
             'appId' => '1234',
         ];
 
-        $queryString = Pusher::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath, [
+        $queryString = self::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath, [
             'filter_by_prefix' => 'presence-global',
         ]);
 
@@ -117,7 +116,7 @@ class FetchChannelsTest extends TestCase
             'appId' => '1234',
         ];
 
-        $queryString = Pusher::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath, [
+        $queryString = self::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath, [
             'filter_by_prefix' => 'presence-global',
             'info' => 'user_count',
         ]);
@@ -156,7 +155,7 @@ class FetchChannelsTest extends TestCase
             'appId' => '1234',
         ];
 
-        $queryString = Pusher::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath, [
+        $queryString = self::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath, [
             'info' => 'user_count',
         ]);
 
@@ -180,7 +179,7 @@ class FetchChannelsTest extends TestCase
             'appId' => '1234',
         ];
 
-        $queryString = Pusher::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath);
+        $queryString = self::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath);
 
         $request = new Request('GET', "{$requestPath}?{$queryString}&".http_build_query($routeParams));
 

--- a/tests/FetchUsersTest.php
+++ b/tests/FetchUsersTest.php
@@ -4,7 +4,6 @@ namespace BeyondCode\LaravelWebSockets\Test;
 
 use BeyondCode\LaravelWebSockets\API\FetchUsers;
 use GuzzleHttp\Psr7\Request;
-use Pusher\Pusher;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class FetchUsersTest extends TestCase
@@ -23,7 +22,7 @@ class FetchUsersTest extends TestCase
             'channelName' => 'my-channel',
         ];
 
-        $queryString = Pusher::build_auth_query_string(
+        $queryString = self::build_auth_query_string(
             'TestKey', 'InvalidSecret', 'GET', $requestPath
         );
 
@@ -50,7 +49,7 @@ class FetchUsersTest extends TestCase
             'channelName' => 'my-channel',
         ];
 
-        $queryString = Pusher::build_auth_query_string(
+        $queryString = self::build_auth_query_string(
             'TestKey', 'TestSecret', 'GET', $requestPath
         );
 
@@ -77,7 +76,7 @@ class FetchUsersTest extends TestCase
             'channelName' => 'invalid-channel',
         ];
 
-        $queryString = Pusher::build_auth_query_string(
+        $queryString = self::build_auth_query_string(
             'TestKey', 'TestSecret', 'GET', $requestPath
         );
 
@@ -101,7 +100,7 @@ class FetchUsersTest extends TestCase
             'channelName' => 'presence-channel',
         ];
 
-        $queryString = Pusher::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath);
+        $queryString = self::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath);
 
         $request = new Request('GET', "{$requestPath}?{$queryString}&".http_build_query($routeParams));
 
@@ -131,7 +130,7 @@ class FetchUsersTest extends TestCase
             'channelName' => 'presence-channel',
         ];
 
-        $queryString = Pusher::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath);
+        $queryString = self::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath);
 
         $request = new Request('GET', "{$requestPath}?{$queryString}&".http_build_query($routeParams));
 

--- a/tests/PresenceChannelTest.php
+++ b/tests/PresenceChannelTest.php
@@ -6,7 +6,6 @@ use BeyondCode\LaravelWebSockets\API\TriggerEvent;
 use BeyondCode\LaravelWebSockets\Server\Exceptions\InvalidSignature;
 use GuzzleHttp\Psr7\Request;
 use Illuminate\Http\JsonResponse;
-use Pusher\Pusher;
 use Ratchet\ConnectionInterface;
 
 class PresenceChannelTest extends TestCase
@@ -419,7 +418,7 @@ class PresenceChannelTest extends TestCase
             'appId' => '1234',
         ];
 
-        $queryString = Pusher::build_auth_query_string(
+        $queryString = self::build_auth_query_string(
             'TestKey', 'TestSecret', 'POST', $requestPath, [
                 'name' => 'some-event',
                 'channels' => ['presence-channel'],
@@ -460,7 +459,7 @@ class PresenceChannelTest extends TestCase
             'appId' => '1234',
         ];
 
-        $queryString = Pusher::build_auth_query_string(
+        $queryString = self::build_auth_query_string(
             'TestKey', 'TestSecret', 'POST', $requestPath, [
                 'name' => 'some-event',
                 'channels' => ['presence-channel'],
@@ -508,7 +507,7 @@ class PresenceChannelTest extends TestCase
             'appId' => '1234',
         ];
 
-        $queryString = Pusher::build_auth_query_string(
+        $queryString = self::build_auth_query_string(
             'TestKey', 'TestSecret', 'POST', $requestPath, [
                 'name' => 'some-event',
                 'channels' => ['presence-channel'],

--- a/tests/PrivateChannelTest.php
+++ b/tests/PrivateChannelTest.php
@@ -6,7 +6,6 @@ use BeyondCode\LaravelWebSockets\API\TriggerEvent;
 use BeyondCode\LaravelWebSockets\Server\Exceptions\InvalidSignature;
 use GuzzleHttp\Psr7\Request;
 use Illuminate\Http\JsonResponse;
-use Pusher\Pusher;
 use Ratchet\ConnectionInterface;
 
 class PrivateChannelTest extends TestCase
@@ -239,7 +238,7 @@ class PrivateChannelTest extends TestCase
             'appId' => '1234',
         ];
 
-        $queryString = Pusher::build_auth_query_string(
+        $queryString = self::build_auth_query_string(
             'TestKey', 'TestSecret', 'POST', $requestPath, [
                 'name' => 'some-event',
                 'channels' => ['private-channel'],
@@ -280,7 +279,7 @@ class PrivateChannelTest extends TestCase
             'appId' => '1234',
         ];
 
-        $queryString = Pusher::build_auth_query_string(
+        $queryString = self::build_auth_query_string(
             'TestKey', 'TestSecret', 'POST', $requestPath, [
                 'name' => 'some-event',
                 'channels' => ['private-channel'],
@@ -328,7 +327,7 @@ class PrivateChannelTest extends TestCase
             'appId' => '1234',
         ];
 
-        $queryString = Pusher::build_auth_query_string(
+        $queryString = self::build_auth_query_string(
             'TestKey', 'TestSecret', 'POST', $requestPath, [
                 'name' => 'some-event',
                 'channels' => ['private-channel'],

--- a/tests/PublicChannelTest.php
+++ b/tests/PublicChannelTest.php
@@ -5,7 +5,6 @@ namespace BeyondCode\LaravelWebSockets\Test;
 use BeyondCode\LaravelWebSockets\API\TriggerEvent;
 use GuzzleHttp\Psr7\Request;
 use Illuminate\Http\JsonResponse;
-use Pusher\Pusher;
 use Ratchet\ConnectionInterface;
 
 class PublicChannelTest extends TestCase
@@ -220,7 +219,7 @@ class PublicChannelTest extends TestCase
             'appId' => '1234',
         ];
 
-        $queryString = Pusher::build_auth_query_string(
+        $queryString = self::build_auth_query_string(
             'TestKey', 'TestSecret', 'POST', $requestPath, [
                 'name' => 'some-event',
                 'channels' => ['public-channel'],
@@ -261,7 +260,7 @@ class PublicChannelTest extends TestCase
             'appId' => '1234',
         ];
 
-        $queryString = Pusher::build_auth_query_string(
+        $queryString = self::build_auth_query_string(
             'TestKey', 'TestSecret', 'POST', $requestPath, [
                 'name' => 'some-event',
                 'channels' => ['public-channel'],
@@ -309,7 +308,7 @@ class PublicChannelTest extends TestCase
             'appId' => '1234',
         ];
 
-        $queryString = Pusher::build_auth_query_string(
+        $queryString = self::build_auth_query_string(
             'TestKey', 'TestSecret', 'POST', $requestPath, [
                 'name' => 'some-event',
                 'channels' => ['public-channel'],

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -10,6 +10,7 @@ use BeyondCode\LaravelWebSockets\Helpers;
 use GuzzleHttp\Psr7\Request;
 use Illuminate\Support\Facades\Redis;
 use Orchestra\Testbench\BrowserKit\TestCase as Orchestra;
+use Pusher\Pusher;
 use React\EventLoop\Factory as LoopFactory;
 
 abstract class TestCase extends Orchestra
@@ -481,5 +482,29 @@ abstract class TestCase extends Orchestra
         if ($this->replicationMode === 'local') {
             $this->markTestSkipped('Skipped test because the replication mode is Local.');
         }
+    }
+
+    protected static function build_auth_query_string(
+        $auth_key,
+        $auth_secret,
+        $request_method,
+        $request_path,
+        $query_params = [],
+        $auth_version = '1.0',
+        $auth_timestamp = null
+    ) {
+        $method = method_exists(Pusher::class, 'build_auth_query_params') ? 'build_auth_query_params' : 'build_auth_query_string';
+
+        $params = Pusher::$method(
+            $auth_key, $auth_secret, $request_method, $request_path, $query_params, $auth_version, $auth_timestamp
+        );
+
+        if ($method == 'build_auth_query_string') {
+            return $params;
+        }
+
+        ksort($params);
+
+        return http_build_query($params);
     }
 }

--- a/tests/TriggerEventTest.php
+++ b/tests/TriggerEventTest.php
@@ -4,7 +4,6 @@ namespace BeyondCode\LaravelWebSockets\Test;
 
 use BeyondCode\LaravelWebSockets\API\TriggerEvent;
 use GuzzleHttp\Psr7\Request;
-use Pusher\Pusher;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class TriggerEventTest extends TestCase
@@ -22,7 +21,7 @@ class TriggerEventTest extends TestCase
             'appId' => '1234',
         ];
 
-        $queryString = Pusher::build_auth_query_string(
+        $queryString = self::build_auth_query_string(
             'TestKey', 'InvalidSecret', 'GET', $requestPath
         );
 


### PR DESCRIPTION
https://github.com/beyondcode/laravel-websockets/pull/885#issuecomment-982707860
>from V6 build_auth_query_string change for build_auth_query_params, tests must be fixed


@mpociot fix breaking changes on tests with latest pusher versions, bug introduced on #885