### PR TITLE
Move doctrine/dbal to suggests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,6 @@
     "require": {
         "cboden/ratchet": "^0.4.1",
         "clue/redis-react": "^2.3",
-        "doctrine/dbal": "^2.9",
         "evenement/evenement": "^2.0|^3.0",
         "facade/ignition-contracts": "^1.0",
         "guzzlehttp/psr7": "^1.5|^2.0",
@@ -53,7 +52,8 @@
         "phpunit/phpunit": "^8.0|^9.0"
     },
     "suggest": {
-        "ext-pcntl": "Running the server needs pcntl to listen to command signals and soft-shutdown."
+        "ext-pcntl": "Running the server needs pcntl to listen to command signals and soft-shutdown.",
+        "doctrine/dbal": "Required to run database migrations (^2.9|^3.0)."
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
`doctrine/dbal` was added in https://github.com/beyondcode/laravel-websockets/commit/375078e686a2374cf1aebd16a394e0044cf15f24

The dependency is only necessary if you intend to run [database/migrations/0000_00_00_000000_rename_statistics_counters.php](https://github.com/beyondcode/laravel-websockets/blob/master/database/migrations/0000_00_00_000000_rename_statistics_counters.php)

This mimics the behavior of [laravel/framework](https://github.com/laravel/framework/blob/8.x/composer.json#L137)

Closes #883