### PR TITLE
Update composer.json for guzzlehttp/psr7 2.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "clue/redis-react": "^2.5",
         "evenement/evenement": "^2.0|^3.0",
         "facade/ignition-contracts": "^1.0",
-        "guzzlehttp/psr7": "^1.7|^2.0",
+        "guzzlehttp/psr7": "^1.7|^2.1",
         "illuminate/broadcasting": "^6.3|^7.0|^8.0",
         "illuminate/console": "^6.3|^7.0|^8.0",
         "illuminate/http": "^6.3|^7.0|^8.0",


### PR DESCRIPTION
Latest Laravel uses guzzle 7.4.1 which requires "guzzlehttp/psr7": "^1.8.3 || ^2.1", and installs 2.1;

Installation has errors cause of versions.  Downgrading breaks requirements for many other packages like aws/aws-sdk-php, intervention/image, etc...


Problem 1
    - beyondcode/laravel-websockets[1.12.0, ..., 1.x-dev] require guzzlehttp/psr7 ^1.5 -> found guzzlehttp/psr7[1.5.0, ..., 1.x-dev] but the package is fixed to 2.1.0 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
    - Root composer.json requires beyondcode/laravel-websockets ^1.12 -> satisfiable by beyondcode/laravel-websockets[1.12.0, 1.x-dev].