### PR TITLE
Fix call to deprecated JsonResponse::create()

### DIFF
--- a/src/API/Controller.php
+++ b/src/API/Controller.php
@@ -215,7 +215,7 @@ abstract class Controller implements HttpServerInterface
      */
     protected function sendAndClose(ConnectionInterface $connection, $response)
     {
-        tap($connection)->send(JsonResponse::create($response))->close();
+        tap($connection)->send(new JsonResponse($response))->close();
     }
 
     /**


### PR DESCRIPTION
Hi there,

Thanks for all the hard work on this awesome package!

`JsonReponse::create` is now deprecated. This PR fixes that method call in `sendAndClose` so this will work with Laravel 9.