### PR TITLE
[1.x] Fix call to deprecated JsonResponse::create()

### DIFF
--- a/src/HttpApi/Controllers/Controller.php
+++ b/src/HttpApi/Controllers/Controller.php
@@ -80,7 +80,7 @@ abstract class Controller implements HttpServerInterface
                 ->ensureValidAppId($laravelRequest->appId)
                 ->ensureValidSignature($laravelRequest);
 
-            $response = JsonResponse::create($this($laravelRequest));
+            $response = new JsonResponse($this($laravelRequest));
 
             $content = $response->content();
 


### PR DESCRIPTION
From #942 – This is the update for the 1.x branch.

Thanks Marcel!