### PR TITLE
[1.x] Update pusher/pusher-php-server versions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,55 +1,99 @@
 name: run-tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - '*'
+    tags:
+      - '*'
+  pull_request:
+    branches:
+      - '*'
 
 jobs:
-    test:
-        runs-on: ${{ matrix.os }}
-        strategy:
-            fail-fast: false
-            matrix:
-                os: [ubuntu-latest, windows-latest]
-                php: [8.0, 7.4, 7.3, 7.2]
-                laravel: [6.*, 7.*, 8.*]
-                dependency-version: [prefer-lowest, prefer-stable]
-                include:
-                    -   laravel: 8.*
-                        testbench: 6.*
-                    -   laravel: 7.*
-                        testbench: 5.*
-                    -   laravel: 6.*
-                        testbench: 4.*
-                exclude:
-                    -   php: 7.2
-                        laravel: 8.*
+  build:
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
 
-        name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
+    runs-on: ubuntu-latest
 
-        steps:
-            -   name: Checkout code
-                uses: actions/checkout@v1
+    strategy:
+      fail-fast: false
+      matrix:
+        php:
+          - '7.3'
+          - '7.4'
+          - '8.0'
+          - '8.1'
+        laravel:
+          - 6.*
+          - 7.*
+          - 8.*
+        prefer:
+          - 'prefer-lowest'
+          - 'prefer-stable'
+        include:
+          - laravel: '6.*'
+            testbench: '4.*'
+            phpunit: '^8.5.8|^9.3.3'
+          - laravel: '7.*'
+            testbench: '5.*'
+            phpunit: '^8.5.8|^9.3.3'
+          - laravel: '8.*'
+            testbench: '6.*'
+            phpunit: '^9.3.3'
+        exclude:
+          - php: '8.0'
+            laravel: 6.*
+            prefer: 'prefer-lowest'
+          - php: '8.0'
+            laravel: 7.*
+            prefer: 'prefer-lowest'
+          - php: '8.1'
+            laravel: 6.*
+          - php: '8.1'
+            laravel: 7.*
+          - php: '8.1'
+            laravel: 8.*
+            prefer: 'prefer-lowest'
 
-            -   name: Cache dependencies
-                uses: actions/cache@v1
-                with:
-                    path: ~/.composer/cache/files
-                    key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
+    name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} --${{ matrix.prefer }}
 
-            -   name: Setup PHP
-                uses: shivammathur/setup-php@v2
-                with:
-                    php-version: ${{ matrix.php }}
-                    extensions: curl, dom, fileinfo, libxml, mbstring, pdo, sqlite, pdo_sqlite, zip
-                    coverage: pcov
+    steps:
+    - uses: actions/checkout@v1
 
-            -   name: Install dependencies
-                run: |
-                    composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
-                    composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php }}
+        extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv
+        coverage: pcov
 
-            -   name: Execute tests
-                run: vendor/bin/phpunit --coverage-text --coverage-clover=coverage.xml
+    - name: Setup Redis
+      uses: supercharge/redis-github-action@1.1.0
+      with:
+        redis-version: 6
 
-            -   uses: codecov/codecov-action@v1
-                with:
-                    fail_ci_if_error: false
+    - uses: actions/cache@v1
+      name: Cache dependencies
+      with:
+        path: ~/.composer/cache/files
+        key: composer-php-${{ matrix.php }}-${{ matrix.laravel }}-${{ matrix.prefer }}-${{ hashFiles('composer.json') }}
+
+    - name: Install dependencies
+      run: |
+        composer require "laravel/framework:${{ matrix.laravel }}" "phpunit/phpunit:${{ matrix.phpunit }}" "orchestra/testbench-browser-kit:${{ matrix.testbench }}" "orchestra/database:${{ matrix.testbench }}" --no-interaction --no-update
+        composer update --${{ matrix.prefer }} --prefer-dist --no-interaction --no-suggest
+
+    - name: Run tests for Local
+      run: |
+        REPLICATION_MODE=local vendor/bin/phpunit --coverage-text --coverage-clover=coverage_local.xml
+
+    - name: Run tests for Redis
+      run: |
+        REPLICATION_MODE=redis vendor/bin/phpunit --coverage-text --coverage-clover=coverage_redis.xml
+
+    - uses: codecov/codecov-action@v1
+      with:
+        fail_ci_if_error: false
+        file: '*.xml'
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "ext-json": "*",
         "cboden/ratchet": "^0.4.1",
         "facade/ignition-contracts": "^1.0",
-        "guzzlehttp/psr7": "^1.5",
+        "guzzlehttp/psr7": "^1.5|^2.0",
         "illuminate/broadcasting": "^6.0|^7.0|^8.0|^9.0",
         "illuminate/console": "^6.0|^7.0|^8.0|^9.0",
         "illuminate/http": "^6.0|^7.0|^8.0|^9.0",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "ext-json": "*",
         "cboden/ratchet": "^0.4.1",
         "facade/ignition-contracts": "^1.0",
-        "guzzlehttp/psr7": "^1.5|^2.0",
+        "guzzlehttp/psr7": "^1.7|^2.0",
         "illuminate/broadcasting": "^6.0|^7.0|^8.0|^9.0",
         "illuminate/console": "^6.0|^7.0|^8.0|^9.0",
         "illuminate/http": "^6.0|^7.0|^8.0|^9.0",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "illuminate/http": "^6.0|^7.0|^8.0|^9.0",
         "illuminate/routing": "^6.0|^7.0|^8.0|^9.0",
         "illuminate/support": "^6.0|^7.0|^8.0|^9.0",
-        "pusher/pusher-php-server": "^3.0|^4.0|^5.0",
+        "pusher/pusher-php-server": "^3.0|^4.0|^5.0|^6.0|^7.0",
         "react/dns": "^1.1",
         "react/http": "^1.1",
         "symfony/http-kernel": "^4.0|^5.0|^6.0",

--- a/src/HttpApi/Controllers/Controller.php
+++ b/src/HttpApi/Controllers/Controller.php
@@ -6,6 +6,7 @@ use BeyondCode\LaravelWebSockets\Apps\App;
 use BeyondCode\LaravelWebSockets\QueryParameters;
 use BeyondCode\LaravelWebSockets\WebSockets\Channels\ChannelManager;
 use Exception;
+use GuzzleHttp\Psr7\Message;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\ServerRequest;
 use Illuminate\Http\JsonResponse;
@@ -110,7 +111,7 @@ abstract class Controller implements HttpServerInterface
             'Content-Length' => strlen($responseData),
         ], $responseData);
 
-        $connection->send(\GuzzleHttp\Psr7\str($response));
+        $connection->send(Message::toString($response));
 
         $connection->close();
     }

--- a/src/Statistics/Logger/HttpStatisticsLogger.php
+++ b/src/Statistics/Logger/HttpStatisticsLogger.php
@@ -6,7 +6,7 @@ use BeyondCode\LaravelWebSockets\Apps\App;
 use BeyondCode\LaravelWebSockets\Statistics\Http\Controllers\WebSocketStatisticsEntriesController;
 use BeyondCode\LaravelWebSockets\Statistics\Statistic;
 use BeyondCode\LaravelWebSockets\WebSockets\Channels\ChannelManager;
-use function GuzzleHttp\Psr7\stream_for;
+use GuzzleHttp\Psr7\Utils;
 use Ratchet\ConnectionInterface;
 use React\Http\Browser;
 
@@ -81,7 +81,7 @@ class HttpStatisticsLogger implements StatisticsLogger
                 ->post(
                     action([WebSocketStatisticsEntriesController::class, 'store']),
                     ['Content-Type' => 'application/json'],
-                    stream_for(json_encode($postData))
+                    Utils::streamFor(json_encode($postData))
                 );
 
             $currentConnectionCount = $this->channelManager->getConnectionCount($appId);

--- a/tests/HttpApi/FetchChannelTest.php
+++ b/tests/HttpApi/FetchChannelTest.php
@@ -7,7 +7,6 @@ use BeyondCode\LaravelWebSockets\Tests\Mocks\Connection;
 use BeyondCode\LaravelWebSockets\Tests\TestCase;
 use GuzzleHttp\Psr7\Request;
 use Illuminate\Http\JsonResponse;
-use Pusher\Pusher;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class FetchChannelTest extends TestCase
@@ -26,7 +25,7 @@ class FetchChannelTest extends TestCase
             'channelName' => 'my-channel',
         ];
 
-        $queryString = Pusher::build_auth_query_string('TestKey', 'InvalidSecret', 'GET', $requestPath);
+        $queryString = self::build_auth_query_string('TestKey', 'InvalidSecret', 'GET', $requestPath);
 
         $request = new Request('GET', "{$requestPath}?{$queryString}&".http_build_query($routeParams));
 
@@ -49,7 +48,7 @@ class FetchChannelTest extends TestCase
             'channelName' => 'my-channel',
         ];
 
-        $queryString = Pusher::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath);
+        $queryString = self::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath);
 
         $request = new Request('GET', "{$requestPath}?{$queryString}&".http_build_query($routeParams));
 
@@ -81,7 +80,7 @@ class FetchChannelTest extends TestCase
             'channelName' => 'presence-global',
         ];
 
-        $queryString = Pusher::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath);
+        $queryString = self::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath);
 
         $request = new Request('GET', "{$requestPath}?{$queryString}&".http_build_query($routeParams));
 
@@ -115,7 +114,7 @@ class FetchChannelTest extends TestCase
             'channelName' => 'invalid-channel',
         ];
 
-        $queryString = Pusher::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath);
+        $queryString = self::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath);
 
         $request = new Request('GET', "{$requestPath}?{$queryString}&".http_build_query($routeParams));
 

--- a/tests/HttpApi/FetchChannelsTest.php
+++ b/tests/HttpApi/FetchChannelsTest.php
@@ -7,7 +7,6 @@ use BeyondCode\LaravelWebSockets\Tests\Mocks\Connection;
 use BeyondCode\LaravelWebSockets\Tests\TestCase;
 use GuzzleHttp\Psr7\Request;
 use Illuminate\Http\JsonResponse;
-use Pusher\Pusher;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class FetchChannelsTest extends TestCase
@@ -25,7 +24,7 @@ class FetchChannelsTest extends TestCase
             'appId' => '1234',
         ];
 
-        $queryString = Pusher::build_auth_query_string('TestKey', 'InvalidSecret', 'GET', $requestPath);
+        $queryString = self::build_auth_query_string('TestKey', 'InvalidSecret', 'GET', $requestPath);
 
         $request = new Request('GET', "{$requestPath}?{$queryString}&".http_build_query($routeParams));
 
@@ -46,7 +45,7 @@ class FetchChannelsTest extends TestCase
             'appId' => '1234',
         ];
 
-        $queryString = Pusher::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath);
+        $queryString = self::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath);
 
         $request = new Request('GET', "{$requestPath}?{$queryString}&".http_build_query($routeParams));
 
@@ -79,7 +78,7 @@ class FetchChannelsTest extends TestCase
             'appId' => '1234',
         ];
 
-        $queryString = Pusher::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath, [
+        $queryString = self::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath, [
             'filter_by_prefix' => 'presence-global',
         ]);
 
@@ -115,7 +114,7 @@ class FetchChannelsTest extends TestCase
             'appId' => '1234',
         ];
 
-        $queryString = Pusher::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath, [
+        $queryString = self::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath, [
             'filter_by_prefix' => 'presence-global',
             'info' => 'user_count',
         ]);
@@ -154,7 +153,7 @@ class FetchChannelsTest extends TestCase
             'appId' => '1234',
         ];
 
-        $queryString = Pusher::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath, [
+        $queryString = self::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath, [
             'info' => 'user_count',
         ]);
 
@@ -178,7 +177,7 @@ class FetchChannelsTest extends TestCase
             'appId' => '1234',
         ];
 
-        $queryString = Pusher::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath);
+        $queryString = self::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath);
 
         $request = new Request('GET', "{$requestPath}?{$queryString}&".http_build_query($routeParams));
 

--- a/tests/HttpApi/FetchUsersTest.php
+++ b/tests/HttpApi/FetchUsersTest.php
@@ -6,7 +6,6 @@ use BeyondCode\LaravelWebSockets\HttpApi\Controllers\FetchUsersController;
 use BeyondCode\LaravelWebSockets\Tests\Mocks\Connection;
 use BeyondCode\LaravelWebSockets\Tests\TestCase;
 use GuzzleHttp\Psr7\Request;
-use Pusher\Pusher;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class FetchUsersTest extends TestCase
@@ -25,7 +24,7 @@ class FetchUsersTest extends TestCase
             'channelName' => 'my-channel',
         ];
 
-        $queryString = Pusher::build_auth_query_string('TestKey', 'InvalidSecret', 'GET', $requestPath);
+        $queryString = self::build_auth_query_string('TestKey', 'InvalidSecret', 'GET', $requestPath);
 
         $request = new Request('GET', "{$requestPath}?{$queryString}&".http_build_query($routeParams));
 
@@ -50,7 +49,7 @@ class FetchUsersTest extends TestCase
             'channelName' => 'my-channel',
         ];
 
-        $queryString = Pusher::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath);
+        $queryString = self::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath);
 
         $request = new Request('GET', "{$requestPath}?{$queryString}&".http_build_query($routeParams));
 
@@ -75,7 +74,7 @@ class FetchUsersTest extends TestCase
             'channelName' => 'invalid-channel',
         ];
 
-        $queryString = Pusher::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath);
+        $queryString = self::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath);
 
         $request = new Request('GET', "{$requestPath}?{$queryString}&".http_build_query($routeParams));
 
@@ -97,7 +96,7 @@ class FetchUsersTest extends TestCase
             'channelName' => 'presence-channel',
         ];
 
-        $queryString = Pusher::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath);
+        $queryString = self::build_auth_query_string('TestKey', 'TestSecret', 'GET', $requestPath);
 
         $request = new Request('GET', "{$requestPath}?{$queryString}&".http_build_query($routeParams));
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -11,6 +11,7 @@ use BeyondCode\LaravelWebSockets\WebSockets\WebSocketHandler;
 use BeyondCode\LaravelWebSockets\WebSocketsServiceProvider;
 use GuzzleHttp\Psr7\Request;
 use Mockery;
+use Pusher\Pusher;
 use Ratchet\ConnectionInterface;
 use React\Http\Browser;
 
@@ -126,5 +127,29 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
     protected function markTestAsPassed()
     {
         $this->assertTrue(true);
+    }
+
+    protected static function build_auth_query_string(
+        $auth_key,
+        $auth_secret,
+        $request_method,
+        $request_path,
+        $query_params = [],
+        $auth_version = '1.0',
+        $auth_timestamp = null
+    ) {
+        $method = method_exists(Pusher::class, 'build_auth_query_params') ? 'build_auth_query_params' : 'build_auth_query_string';
+
+        $params = Pusher::$method(
+            $auth_key, $auth_secret, $request_method, $request_path, $query_params, $auth_version, $auth_timestamp
+        );
+
+        if ($method == 'build_auth_query_string') {
+            return $params;
+        }
+
+        ksort($params);
+
+        return http_build_query($params);
     }
 }


### PR DESCRIPTION
Hi there,

This PR updates the versions for pusher-php-server to match the master branch. In Laravel 9 I believe you need to use version ^7.0.

- This will make the 1.x version useable in Laravel 9.
- All of these changes are already reflected in the master branch

Fixes #951 
Fixes #956
Fixes #945 
Fixes #943 