### PR TITLE
[1.x] DnsResolver - incorrect return type fixed

### DIFF
--- a/src/Statistics/DnsResolver.php
+++ b/src/Statistics/DnsResolver.php
@@ -19,17 +19,12 @@ class DnsResolver implements ResolverInterface
 
     public function resolve($domain)
     {
-        return $this->resolveInternal($domain);
+        return new FulfilledPromise($this->internalIP);
     }
 
     public function resolveAll($domain, $type)
     {
-        return $this->resolveInternal($domain, $type);
-    }
-
-    private function resolveInternal($domain, $type = null)
-    {
-        return new FulfilledPromise($this->internalIP);
+        return new FulfilledPromise([$this->internalIP]);
     }
 
     public function __toString()


### PR DESCRIPTION
Problem: no entries in websockets_statistics_entries table.

How to reproduce:
1. set env APP_URL to any hostname (e.g. "localhost") to make dns resolver work.
2. set config websockets.statistics.perform_dns_lookup to false to enable dns resolver from this package.

Caused by incorrect return type from BeyondCode\LaravelWebSockets\Statistics\DnsResolver, resolve() must return string, resolveAll() - array.

Possible workaround - set config websockets.statistics.perform_dns_lookup to true, in that case BeyondCode\LaravelWebSockets\Statistics\DnsResolver will not replace default dns resolver.

Fix - change return type (which is made in this commit).
Required return types described in React\Dns\Resolver\ResolverInterface interface.