### PR TITLE
fix: Account for CarbonImmutable used in Laravel projects in CleanStatistics command

### DIFF
--- a/src/Console/Commands/CleanStatistics.php
+++ b/src/Console/Commands/CleanStatistics.php
@@ -45,8 +45,9 @@ class CleanStatistics extends Command
          * but StatisticsStore expects an actual Carbon instance,
          * so we'll convert it here.
          */
-        if ($timestamp instanceof CarbonImmutable)
+        if ($timestamp instanceof CarbonImmutable) {
             $timestamp = new Carbon($timestamp);
+        }
 
         $amountDeleted = StatisticsStore::delete(
             $timestamp, $this->argument('appId')

--- a/src/Console/Commands/CleanStatistics.php
+++ b/src/Console/Commands/CleanStatistics.php
@@ -3,7 +3,9 @@
 namespace BeyondCode\LaravelWebSockets\Console\Commands;
 
 use BeyondCode\LaravelWebSockets\Facades\StatisticsStore;
+use Carbon\CarbonImmutable;
 use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
 
 class CleanStatistics extends Command
 {
@@ -35,8 +37,19 @@ class CleanStatistics extends Command
 
         $days = $this->option('days') ?: config('statistics.delete_statistics_older_than_days');
 
+        $timestamp = now()->subDays($days);
+
+        /*
+         * Laravel projects may be configured to use CarbonImmutable,
+         * so now() would give us an immutable instance,
+         * but StatisticsStore expects an actual Carbon instance,
+         * so we'll convert it here.
+         */
+        if ($timestamp instanceof CarbonImmutable)
+            $timestamp = new Carbon($timestamp);
+
         $amountDeleted = StatisticsStore::delete(
-            now()->subDays($days), $this->argument('appId')
+            $timestamp, $this->argument('appId')
         );
 
         $this->info("Deleted {$amountDeleted} record(s) from the WebSocket statistics storage.");


### PR DESCRIPTION
Laravel projects can easily be globally configured to use CarbonImmutable objects instead of normal mutable ones.

Projects like this cause an exception when running `CleanStatistics` command:
```
BeyondCode\LaravelWebSockets\Statistics\Stores\DatabaseStore::delete():
Argument #1 ($moment) must be of type Carbon\Carbon, Carbon\CarbonImmutable given, called in
/home/app/michman/vendor/laravel/framework/src/Illuminate/Support/Facades/Facade.php on line 337
```

Proper fix would be to declare Carbon instances in `StatisticsStore` interface as `CarbonInterface`, but this would break the existing stores, so this PR suggests a slightly dirty fix to this issue.