### PR TITLE
Added error context

### DIFF
--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -391,6 +391,7 @@
               .post('/event', payload)
               .then(() => {})
               .catch(err => {
+                console.error(err);
                 alert('Error sending event.');
               })
               .then(() => {


### PR DESCRIPTION
This should be here by default. 
The “Error sending event” message isn't useful at all