### PR TITLE
Update StartWebSocketServer

### DIFF
--- a/src/Console/StartWebSocketServer.php
+++ b/src/Console/StartWebSocketServer.php
@@ -60,7 +60,7 @@ class StartWebSocketServer extends Command
                 'verify_peer' => config('app.env') === 'production',
                 'verify_peer_name' => config('app.env') === 'production',
             ],
-            'happy_eyeballs' => false
+            'happy_eyeballs' => false,
         ]);
 
         $browser = new Browser($this->loop, $connector);

--- a/src/Console/StartWebSocketServer.php
+++ b/src/Console/StartWebSocketServer.php
@@ -60,6 +60,7 @@ class StartWebSocketServer extends Command
                 'verify_peer' => config('app.env') === 'production',
                 'verify_peer_name' => config('app.env') === 'production',
             ],
+            'happy_eyeballs' => false
         ]);
 
         $browser = new Browser($this->loop, $connector);


### PR DESCRIPTION
The HttpStatisticsLogger couldn't save statistics on database. Using Laravel 10, I can see that there is a fundamental redesign of Laravel-websockets 2.x concerning the Statistics but on 1.14 version this code does not work as attempted :


HttpStatisticsLogger.php -> Line 79

```
$this
    ->browser
    ->post(
        action([WebSocketStatisticsEntriesController::class, 'store']),    
        ['Content-Type' => 'application/json'],
        Utils::streamFor(json_encode($postData))
);
```

everything seems correct except the $this->browser who probably should be misconfigured.
I actually succeeded to send a post request from Insomnia with the information in the $this->browser->post() method so the problem should probably be the poster.

And actually I found out it was not correctly configured as we can see here in StartWebSocketServer :

```
$connector = new Connector($this->loop, [
    'dns' => $this->getDnsResolver(),
    'tls' => [
        'verify_peer' => config('app.env') === 'production',
        'verify_peer_name' => config('app.env') === 'production',
    ],
]);
```


$browser = new Browser($this->loop, $connector);
If I replace $this->getDnsResolver() with 127.0.0.1 it works. So the problem comes from the Connecter receiving the 'dns' :


```
vendor/react/socket/src/Connector.php Line 93 :

        if ($context['dns'] !== false) 
        {
            if ($context['dns'] instanceof ResolverInterface) 
            {
                $resolver = $context['dns'];
            } 
            else 
            {
                if ($context['dns'] !== true) {
                    $config = $context['dns'];
                } else {
                    // try to load nameservers from system config or default to Google's public DNS
                    $config = DnsConfig::loadSystemConfigBlocking();
                    if (!$config->nameservers) {
                        $config->nameservers[] = '8.8.8.8'; // @codeCoverageIgnore
                    }
                }

                $factory = new DnsFactory();
                $resolver = $factory->createCached(
                    $config,
                    $loop
                );
            }

            if( $context['happy_eyeballs'] === true ) 
            {
                $tcp = new HappyEyeBallsConnector($loop, $tcp, $resolver);
            } 
            else 
            {
                $tcp = new DnsConnector($tcp, $resolver);
            }
        }
```

When focusing on the code, I figure out that the `happy_eyeballs [ always true when not indicated ] creates à new HappyEyeBallsConnctor instead of the DnsConnector normally working. So :

I tried to add a happy_eyeballs => false in the connector context array and it solved the problem.


```
$connector = new Connector($this->loop, [
    'dns' => $this->getDnsResolver(),
    'tls' => [
        'verify_peer' => config('app.env') === 'production',
        'verify_peer_name' => config('app.env') === 'production',
     ],
    'happy_eyeballs' => false
]);
```

Hope this helps.

Adding additional `happy_eyeballs => false` item in context parameters to return a DnsConnector instead of HappyEyeBallsConnector.