### PR TITLE
Fix Symfony deprecation error in TriggerEventController

### DIFF
--- a/src/HttpApi/Controllers/TriggerEventController.php
+++ b/src/HttpApi/Controllers/TriggerEventController.php
@@ -16,7 +16,7 @@ class TriggerEventController extends Controller
         if ($payload->has('channel')) {
             $channels = [$payload->get('channel')];
         } else {
-            $channels = optional($payload->all()['channels']) ?? [];
+            $channels = $payload->all()['channels'] ?? [];
 
             if (is_string($channels)) {
                 $channels = [$channels];

--- a/src/HttpApi/Controllers/TriggerEventController.php
+++ b/src/HttpApi/Controllers/TriggerEventController.php
@@ -16,7 +16,7 @@ class TriggerEventController extends Controller
         if ($payload->has('channel')) {
             $channels = [$payload->get('channel')];
         } else {
-            $channels = $payload->get('channels', []);
+            $channels = optional($payload->all()['channels']) ?? [];
 
             if (is_string($channels)) {
                 $channels = [$channels];


### PR DESCRIPTION
Should fix #1146 that is caused by Symfony deprecating non-scalar values in InputBag.php.