### PR TITLE
Update actions/checkout to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} --${{ matrix.prefer }}
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2


### PR DESCRIPTION
Update actions/checkout to v4
[actions/checkout/releases/v4.0.0](https://github.com/actions/checkout/releases/tag/v4.0.0)