### PR TITLE
Mark package as abandoned.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
             "role": "Developer"
         }
     ],
+    "abandoned": true,
     "require": {
         "php": "^8.0|^8.1",
         "cboden/ratchet": "^0.4.4",


### PR DESCRIPTION
Due to the package not being compatible with the most recent versions of Laravel, being removed from the Laravel documentation as a recommendation, and a clear indication from the excess number of unanswered issues and unmerged pull requests it's only fair to fellow developers to mark this as abandoned.

We've all been in a position where we've wasted hours of dev time trying to use a package only to find its no longer maintained, and this is no exception. 

Whilst this is an exceptional package, **it's time to do the right thing and end the chapter**. Should it ever go back into active maintenance again in the future this flag can be removed.